### PR TITLE
Node 0.6.* fix

### DIFF
--- a/phantom.js
+++ b/phantom.js
@@ -9,7 +9,7 @@
 
   listenOnSomePort = function(app) {
     try {
-      // Use a random port. Node 0.6.* no longer throws on port is use within `listen`.
+      // Use a random port. Node 0.6.* no longer throws exceptions within 'listen'.
       app.listen();
       return app.address().port;
     } catch (err) {


### PR DESCRIPTION
Inside phantom.js you used a try/catch block to check which port to run on. Node 0.6.\* no longer throws exceptions within the scope of 'listen' so this approach no longer works. 

Work around is to let node decide which port to run on, and return that instead (Should be faster too I think).
