### PR TITLE
Allow access to the 'raw' phantomjs process

### DIFF
--- a/phantom.coffee
+++ b/phantom.coffee
@@ -51,6 +51,7 @@ module.exports =
     server.listen appServer, {io}, (obj, conn) ->
       phantom = conn.remote
       wrap phantom
+      phantom.process = ps
       phanta.push phantom
       cb? phantom
 

--- a/phantom.js
+++ b/phantom.js
@@ -78,6 +78,7 @@
       }, function(obj, conn) {
         phantom = conn.remote;
         wrap(phantom);
+        phantom.process = ps;
         phanta.push(phantom);
         return typeof cb === "function" ? cb(phantom) : void 0;
       });

--- a/test/kill.coffee
+++ b/test/kill.coffee
@@ -1,0 +1,39 @@
+vows    = require 'vows'
+assert  = require 'assert'
+psTree  = require 'ps-tree'
+child   = require 'child_process'
+phantom = require '../phantom'
+
+
+describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
+
+# Make coffeescript not return anything
+# This is needed because vows topics do different things if you have a return value
+t = (fn) ->
+  (args...) ->
+    fn.apply this, args
+    return
+
+describe "The phantom module"
+  "Can create an instance":
+    topic: t -> phantom.create (p) => @callback null, p
+    
+    "which also has a process": (p) -> assert.isObject p.process
+    
+    "which, when killed":
+      topic: t (p) ->
+        test = this
+
+        setTimeout ->
+          p.process.kill 'SIGKILL'
+          setTimeout ->
+            psTree process.pid, test.callback
+          , 500
+        , 500
+
+      "stops running completely": (children) ->
+        assert.equal children.length, 1, "process still has #{children.length} child(ren): #{JSON.stringify children}"
+
+
+
+      


### PR DESCRIPTION
This pull request makes the phantomjs child process accessible, this way you can kill the process should it take too long (or if it's crashed). Plus you can access the process' stdin/stdout/stderr streams
