### PR TITLE
Tiny change to adress warning message displayed with current express (3.0.0rc5)

### DIFF
--- a/phantom.js
+++ b/phantom.js
@@ -50,7 +50,7 @@
     create: function() {
       var app, appServer, args, cb, io, phantom, ps, server, _i;
       args = 2 <= arguments.length ? __slice.call(arguments, 0, _i = arguments.length - 1) : (_i = 0, []), cb = arguments[_i++];
-      app = express.createServer();
+      app = express();
       app.use(express.static(__dirname));
       appServer = app.listen();
       server = dnode();


### PR DESCRIPTION
Your package.json specifies 

"express": "~3.0.0"

and the current version of express 3.0.0rc5 throws this warning when you use your module:

Warning: express.createServer() is deprecated, express
applications no longer inherit from http.Server,
please use:

  var express = require("express");
  var app = express();

I just made the suggested change.
