### PR TITLE
Reopen Fix passing command line arguments to "create"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ phantom.create (ph) ->
 
 In Javascript, do the same but add parentheses and curly braces everywhere.
 
-You can use all the methods listed on the [PhantomJS API page](http://code.google.com/p/phantomjs/wiki/Interface)
+You can use all the methods listed on the [PhantomJS API page](https://github.com/ariya/phantomjs/wiki/API-Reference)
 
 
 Due to the async nature of the bridge, some things have changed, though:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "browserify": "1.10.9",
         "traverse": "~0.6.3",
         "coffee-script": "~1.3.3",
+        "express": "3.2.5",
         "temp": "~0.4.0",
         "ps-tree": "~0.0.2",
         "vows": "~0.6.2"

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -43,7 +43,7 @@ module.exports =
       switch typeof arg
         when 'function' then cb = arg
         when 'string' then args.push arg
-        when 'object' then options = v
+        when 'object' then options = arg
     options.binary ?= 'phantomjs'
     options.port ?= 12300
 

--- a/phantom.js
+++ b/phantom.js
@@ -68,7 +68,7 @@
             args.push(arg);
             break;
           case 'object':
-            options = v;
+            options = arg;
         }
       }
       if ((_ref = options.binary) == null) {

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -14,48 +14,55 @@ t = (fn) ->
     fn.apply this, args
     return
 
-describe "The phantom module"
+describe "The phantom module (basic)"
   "Can create an instance":
-    topic: t -> phantom.create (p) => @callback null, p
+    topic: t ->
+      phantom.create {port: 12302}, (ph) =>
+        @callback null, ph
     
-    "which is an object": (p) -> assert.isObject p
+    "which is an object": (ph) ->
+      assert.isObject ph
     
     "with a version":
-      topic: t (p) -> p.get 'version', (val) => @callback null, val
+      topic: t (ph) ->
+        ph.get 'version', (val) =>
+          @callback null, val
       
-      "defined": (ver) -> assert.notEqual ver, undefined
+      "defined": (ver) ->
+        assert.notEqual ver, undefined
       
       "greater than or equal to 1.3": (ver) ->
         assert.ok ver.major >= 1, "major version too low"
         assert.ok ver.minor >= 3, "minor version too low"
 
-
     "which can inject Javascript from a file":
-      topic: t (p) ->
-        p.injectJs 'test/inject.js', (success) =>
-          @callback null, (success)
+      topic: t (ph) ->
+        ph.injectJs 'test/inject.js', (success) =>
+          @callback null, success
       
       "and succeed": (success) ->
         assert.ok success, "Injection should return true"
 
     "which can create a page":
-      topic: t (p) -> p.createPage (page) => @callback null, page
+      topic: t (ph) ->
+        ph.createPage (page) =>
+          @callback null, page
 
-      "which is an object": (page) -> assert.isObject page
+      "which is an object": (page) ->
+        assert.isObject page
 
     "which, when you call exit()":
-      topic: t (p) ->
-        test = this
-        
+      topic: t (ph) ->
         # Make sure other tests get a chance to run first. There's probably a better way to do this.
-        setTimeout ->
-          p.exit()
-          setTimeout ->
-            psTree process.pid, test.callback
-          , 500
+        setTimeout =>
+          psTree process.pid, (err, oldChildren) =>
+            ph.exit()
+            setTimeout =>
+              psTree process.pid, (err, newChildren) =>
+                @callback null, oldChildren, newChildren
+            , 500
         , 500
-      "exits after 500ms": (children) ->
-        # 1 instead of 0 because pstree spawns a subprocess
-        assert.equal children.length, 1, "process still has #{children.length} child(ren): #{JSON.stringify children}"
-        
+
+      "exits after 500ms": (err, oldChildren, newChildren) ->
+        assert.equal oldChildren.length - newChildren.length, 1, "process still has #{newChildren.length} child(ren): #{JSON.stringify newChildren}"
 

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -6,7 +6,6 @@ temp    = require 'temp'
 path    = require 'path'
 fs      = require 'fs'
 
-
 describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
 
 # Make coffeescript not return anything
@@ -39,10 +38,9 @@ appServer = app.listen()
 describe "Pages"
   "A Phantom page":
     topic: t ->
-      test = this
-      phantom.create (p) ->
-        p.createPage (page) ->
-          test.callback null, page, p
+      phantom.create {port: 12303}, (ph) =>
+        ph.createPage (page) =>
+          @callback null, page, ph
 
     "can open a URL on localhost":
       topic: t (page) ->
@@ -53,14 +51,15 @@ describe "Pages"
         assert.equal status, "success"
 
       "and the page, once it loads,":
-        topic: t (page) ->
+        topic: t (page, status) ->
           setTimeout =>
             @callback null, page
           , 1500
 
         "has a title":
           topic: t (page) ->
-            page.evaluate (-> document.title), (title) => @callback null, title
+            page.evaluate (-> document.title), (title) =>
+              @callback null, title
 
           "which is correct": (title) ->
             assert.equal title, "Test page title"
@@ -68,15 +67,15 @@ describe "Pages"
         "can inject Javascript from a file":
           topic: t (page) ->
             page.injectJs 'test/inject.js', (success) =>
-              @callback null, (success)
+              @callback null, success
 
           "and succeed": (success) ->
             assert.ok success, "Injection should return true"
 
-
         "can evaluate DOM nodes":
           topic: t (page) ->
-            page.evaluate (-> document.getElementById('somediv')), (node) => @callback null, node
+            page.evaluate (-> document.getElementById('somediv')), (node) =>
+              @callback null, node
 
           "which match": (node) ->
             assert.equal node.tagName, 'DIV'
@@ -84,52 +83,66 @@ describe "Pages"
 
         "can evaluate scripts defined in the header":
           topic: t (page) ->
-            page.evaluate (-> $('#somediv').html()), (html) => @callback null, html
+            page.evaluate (-> $('#somediv').html()), (html) =>
+              @callback null, html
 
           "which return the correct result": (html) ->
             html = html.replace(/\s\s+/g, "")
             assert.equal html, '<div class="anotherdiv">Some page content</div>'
-
+        
         "can set a nested property":
           topic: t (page) ->
-            page.set 'settings.loadPlugins', true, (oldVal) => @callback null, page, oldVal
+            page.set 'settings.loadPlugins', true, (oldVal) =>
+              @callback null, page, oldVal
 
           "and get it again":
             topic: t (page, oldVal) ->
-              page.get 'settings.loadPlugins', (val) => @callback null, oldVal, val
+              page.get 'settings.loadPlugins', (val) =>
+                @callback null, oldVal, val
 
-            "and they match": (_, oldVal, val) ->
+            "and they match": (err, oldVal, val) ->
               assert.equal oldVal, val
 
         "can simulate clicks on page locations":
           topic: t (page) ->
             page.sendEvent 'click', 133, 133
-            page.evaluate (-> window.i_got_clicked), (clicked) => @callback null, clicked
+            page.evaluate (-> window.i_got_clicked), (clicked) =>
+              @callback null, clicked
 
           "and have those clicks register": (clicked) ->
             assert.ok clicked
 
-        "can register an onConsoleMessage handler":
+        ###
+        "can register an onAlert handler":
           topic: t (page) ->
-            test = this
-            page.set 'onConsoleMessage', (msg) -> test.callback null, msg
-            page.evaluate (-> console.log "Hello, world!")
+            page.set 'onAlert', (msg) =>
+              @callback null, msg
+            page.evaluate (-> alert "Hello, world!")
 
           "which works correctly": (msg) ->
             assert.equal msg, "Hello, world!"
 
+        "can register an onConsoleMessage handler":
+          topic: t (page) ->
+            page.set 'onConsoleMessage', (msg) =>
+              @callback null, msg
+            page.evaluate (-> console.log "Hello, world!")
+
+          "which works correctly": (msg) ->
+            assert.equal msg, "Hello, world!"
+        ###
+
         "can render the page to a file":
           topic: t (page) ->
-            test     = this
             fileName = temp.path suffix: '.png'
-            page.render fileName, -> test.callback null, fileName
+            page.render fileName, =>
+              @callback null, fileName
 
           "which is created": (fileName) ->
             assert.ok fs.existsSync(fileName), "rendered image should exist"
 
           teardown: (fileName) ->
             fs.unlink fileName
-
     teardown: (page, ph) ->
       appServer.close()
       ph.exit()


### PR DESCRIPTION
https://github.com/sgentle/phantomjs-node/pull/82
- fix bug in previous merge
- add express to devDependencies
- clean up tests
  - consistent naming with ph
  - using @callback instead of test.callback
  - naming parameters instead of _, _1, _2
  - add test for create with arguments, but seems like we'd need to give phantom more info to test this fully.  or arguments aren't passing through the shim correctly because get "args" returns just [port] instead of ["--load-images=yes", port].  phantomjs is also deprecating this and telling us to use system.args, which would mean exposing this data elsewhere.
  - create phantom's on different ports for each test file so "cake test" works
- fix API reference link

I commented out the onAlert and onConsoleMessage tests.  They are crashing for me. Can someone else try them out and see if they get the same result? Do we need to update the shim to support these?

phantom stderr: PhantomJS has crashed. Please read the crash reporting guide at https://github.com/ariya/phantomjs/wiki/Crash-Reporting and file a bug report at https://github.com/ariya/phantomjs/issues/new with the crash dump file attached: /tmp/8CEC6982-871F-4606-933A-F98BF5715B07.dmp
