### PR TITLE
Added `page.goBack()` and `page.goForward()`

### DIFF
--- a/shim.coffee
+++ b/shim.coffee
@@ -45,7 +45,7 @@ mkwrap = (src, pass=[], special={}) ->
   obj
 
 pageWrap = (page) -> mkwrap page,
-  ['open','close','includeJs','sendEvent','release','uploadFile','close']
+  ['open','close','includeJs','sendEvent','release','uploadFile','close','goBack','goForward']
   injectJs: (js, cb=->) -> cb page.injectJs js
   evaluate: (fn, cb=(->), args...) -> cb page.evaluate.apply(page, [fn].concat(args))
   render: (file, cb=->) -> page.render file; cb()

--- a/shim.js
+++ b/shim.js
@@ -4614,7 +4614,7 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
   };
 
   pageWrap = function(page) {
-    return mkwrap(page, ['open', 'close', 'includeJs', 'sendEvent', 'release', 'uploadFile', 'close'], {
+    return mkwrap(page, ['open', 'close', 'includeJs', 'sendEvent', 'release', 'uploadFile', 'close', 'goBack', 'goForward'], {
       injectJs: function(js, cb) {
         if (cb == null) cb = function() {};
         return cb(page.injectJs(js));


### PR DESCRIPTION
Quick fix for #91, just added to the wrap the two missing methods
`page.goBack()` and `page.goForward()`.

I guess there is no need for testing.

I am not sure about the method `page.go(index)` hence I did not add it.
