### PR TITLE
Pick open port automatically

### DIFF
--- a/phantom.coffee
+++ b/phantom.coffee
@@ -46,7 +46,7 @@ module.exports =
         when 'string' then args.push arg
         when 'object' then options = arg
     options.binary ?= 'phantomjs'
-    options.port ?= 12300
+    options.port ?= 0
 
     phantom = null
 

--- a/phantom.js
+++ b/phantom.js
@@ -81,7 +81,7 @@
         options.binary = 'phantomjs';
       }
       if ((_ref1 = options.port) == null) {
-        options.port = 12300;
+        options.port = 0;
       }
       phantom = null;
       httpServer = http.createServer();


### PR DESCRIPTION
Binding to port `0` automatically chooses a random free port.

Useful if `12300` is already taken on the machine. Or you are trying to spawn multiple phantomjs workers.
