### PR TITLE
Replace p. with page. and p.page. with page.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ Due to the async nature of the bridge, some things have changed, though:
 
 * Return values (ie, of ```page.evaluate```) are returned in a callback instead
 * ```page.render()``` takes a callback so you can tell when it's done writing the file
-* Properties can't be get/set directly, instead use ```p.get('version', callback)``` or ```p.page.set('viewportSize', {width:640,height:480})```, etc. Nested objects can be accessed by including dots in keys, such as ```p.page.set('settings.loadImages', false)```
+* Properties can't be get/set directly, instead use ```page.get('version', callback)``` or ```page.set('viewportSize', {width:640,height:480})```, etc. Nested objects can be accessed by including dots in keys, such as ```page.set('settings.loadImages', false)```
 * Callbacks can't be set directly, instead use ```page.set('callbackName', callback)```, e.g. ```page.set('onLoadFinished', function(success) {})```
 * onResourceRequested takes a function that executes in the scope of phantom which has access to ```request.abort()```, ```request.changeUrl(url)```, and ```request.setHeader(key,value)```. The second argument is the callback which can execute in the scope of your code, with access to just the requestData. e.g.
 ```


### PR DESCRIPTION
This part of the documentation was confusing since a `p` variable wasn't mentioned previously. After using this library I realized what it was really talking about is the object in the `ph.createPage` callback, previously referred to as `page`. Therefore, I thought it made the most sense to refer to it as `page` here as well.
