### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.test

--- a/package.json
+++ b/package.json
@@ -1,41 +1,42 @@
 {
-    "author": "Sam Gentle <sam@samgentle.com>",
-    "name": "phantom",
-    "description": "PhantomJS wrapper for Node",
-    "homepage": "https://github.com/sgentle/phantomjs-node",
-    "version": "0.5.7",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/sgentle/phantomjs-node.git"
-    },
-    "contributors": [
-        {
-            "name": "Amir Raminfar",
-            "email": "findamir@gmail.com"
-        }
-    ],
-    "main": "phantom.js",
-    "engines": {
-        "node": ">=v0.4.9"
-    },
-    "dependencies": {
-        "dnode": "^1.2.0",
-        "shoe": "~0.0.10"
-    },
-    "devDependencies": {
-        "browserify": "1.10.9",
-        "traverse": "~0.6.3",
-        "coffee-script": "~1.7.1",
-        "express": "3.2.5",
-        "temp": "~0.4.0",
-        "ps-tree": "~0.0.2",
-        "vows": "~0.6.2"
-    },
-    "licenses": {
-        "type": "MIT",
-        "url": "http://www.opensource.org/licenses/MIT"
-    },
-    "scripts": {
-        "test": "cake test"
+  "author": "Sam Gentle <sam@samgentle.com>",
+  "name": "phantom",
+  "description": "PhantomJS wrapper for Node",
+  "homepage": "https://github.com/sgentle/phantomjs-node",
+  "version": "0.5.7",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sgentle/phantomjs-node.git"
+  },
+  "contributors": [
+    {
+      "name": "Amir Raminfar",
+      "email": "findamir@gmail.com"
     }
+  ],
+  "main": "phantom.js",
+  "engines": {
+    "node": ">=v0.4.9"
+  },
+  "dependencies": {
+    "dnode": "^1.2.0",
+    "shoe": "~0.0.10"
+  },
+  "devDependencies": {
+    "browserify": "1.10.9",
+    "traverse": "~0.6.3",
+    "coffee-script": "~1.7.1",
+    "express": "3.2.5",
+    "temp": "~0.4.0",
+    "ps-tree": "~0.0.2",
+    "vows": "~0.7.0",
+    "bluebird": "^1.2.3"
+  },
+  "licenses": {
+    "type": "MIT",
+    "url": "http://www.opensource.org/licenses/MIT"
+  },
+  "scripts": {
+    "test": "cake test"
+  }
 }

--- a/test/adv.coffee
+++ b/test/adv.coffee
@@ -8,8 +8,8 @@ describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
 # Make coffeescript not return anything
 # This is needed because vows topics do different things if you have a return value
 t = (fn) ->
-  (args...) ->
-    fn.apply this, args
+  ->
+    fn.apply this, arguments
     return
 
 app = express()
@@ -29,7 +29,7 @@ app.get '/', (req, res) ->
 
 appServer = app.listen()
 
-describe "The phantom module (adv)"
+describe "The phantom module (adv)",
   "Can create an instance with --load-images=no":
     topic: t ->
       phantom.create '--load-images=no', (ph) =>
@@ -77,4 +77,3 @@ describe "The phantom module (adv)"
 
     "which loads on the correct port": (port) ->
       assert.equal port, 12301
-

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -10,27 +10,27 @@ describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
 # Make coffeescript not return anything
 # This is needed because vows topics do different things if you have a return value
 t = (fn) ->
-  (args...) ->
-    fn.apply this, args
+  ->
+    fn.apply this, arguments
     return
 
-describe "The phantom module (basic)"
+describe "The phantom module (basic)",
   "Can create an instance":
     topic: t ->
       phantom.create {port: 12302}, (ph) =>
         @callback null, ph
-    
+
     "which is an object": (ph) ->
       assert.isObject ph
-    
+
     "with a version":
       topic: t (ph) ->
         ph.get 'version', (val) =>
           @callback null, val
-      
+
       "defined": (ver) ->
         assert.notEqual ver, undefined
-      
+
       "greater than or equal to 1.3": (ver) ->
         assert.ok ver.major >= 1, "major version too low"
         assert.ok ver.minor >= 3, "minor version too low"
@@ -39,7 +39,7 @@ describe "The phantom module (basic)"
       topic: t (ph) ->
         ph.injectJs 'test/inject.js', (success) =>
           @callback null, success
-      
+
       "and succeed": (success) ->
         assert.ok success, "Injection should return true"
 
@@ -65,4 +65,3 @@ describe "The phantom module (basic)"
 
       "exits after 500ms": (err, oldChildren, newChildren) ->
         assert.equal oldChildren.length - newChildren.length, 1, "process still has #{newChildren.length} child(ren): #{JSON.stringify newChildren}"
-

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -11,8 +11,8 @@ describe = (name, bat) -> vows.describe(name).addBatch(bat).export(module)
 # Make coffeescript not return anything
 # This is needed because vows topics do different things if you have a return value
 t = (fn) ->
-  (args...) ->
-    fn.apply this, args
+  ->
+    fn.apply this, arguments
     return
 
 app = express()
@@ -35,7 +35,7 @@ app.get '/', (req, res) ->
 
 appServer = app.listen()
 
-describe "Pages"
+describe "Pages",
   "A Phantom page":
     topic: t ->
       phantom.create {port: 12303}, (ph) =>
@@ -89,7 +89,7 @@ describe "Pages"
           "which return the correct result": (html) ->
             html = html.replace(/\s\s+/g, "")
             assert.equal html, '<div class="anotherdiv">Some page content</div>'
-        
+
         "can set a nested property":
           topic: t (page) ->
             page.set 'settings.loadPlugins', true, (oldVal) =>


### PR DESCRIPTION
- Fixes #52
- vows version bump
- Implement better streaming command runner in `Cakefile`
- Syntax fixes and minor enhancements for test suites
- Precompile test suites and run them in JS (see flatiron/vows/#296)
- Cakefile enhancements
  - New command runner (ensures proper sequencing, streaming output,
    output color support)
  - `cleanup` task and helper
