### PR TITLE
Fix render shim backward compatibility

### DIFF
--- a/shim.coffee
+++ b/shim.coffee
@@ -59,7 +59,15 @@ pageWrap = (page) -> mkwrap page,
       cb.apply(this, arguments)
   injectJs: (js, cb=->) -> cb page.injectJs js
   evaluate: (fn, cb=(->), args...) -> cb page.evaluate.apply(page, [fn].concat(args))
-  render: (file, opts={}, cb=->) -> page.render file, opts; cb()
+  render: (file, opts={}, cb) ->
+    unless cb?
+      if typeof opts is 'function'
+        cb = opts
+        opts = {}
+      else
+        cb = ->
+
+    page.render file, opts; cb()
   getContent: (cb=->) -> cb page.content
   renderBase64: (type, cb=->) -> cb page.renderBase64 type
   setHeaders: (headers, cb=->) -> page.customHeaders = headers; cb()

--- a/shim.js
+++ b/shim.js
@@ -5496,7 +5496,14 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
       },
       render: function(file, opts, cb) {
         if (opts == null) opts = {};
-        if (cb == null) cb = function() {};
+        if (cb == null) {
+          if (typeof opts === 'function') {
+            cb = opts;
+            opts = {};
+          } else {
+            cb = function() {};
+          }
+        }
         page.render(file, opts);
         return cb();
       },


### PR DESCRIPTION
- Add support for old syntax `page.render url, callback`
- Rebuild
