### PR TITLE
Add page.onConsoleMessage instead of using set('onConsoleMessage', cb)

### DIFF
--- a/shim.coffee
+++ b/shim.coffee
@@ -47,6 +47,10 @@ mkwrap = (src, pass=[], special={}) ->
 pageWrap = (page) -> mkwrap page,
   ['open','close','includeJs','sendEvent','release','uploadFile','goBack','goForward','reload']
   # this is here to let the user pass in a function that has access to request.abort() and other functions on the request object.
+  onConsoleMessage: (fn, cb=(->)) ->
+    page.onConsoleMessage = ->
+      fn.apply(this, arguments)
+    cb()
   onResourceRequested: (fn, cb=(->)) ->
     page.onResourceRequested = ->
       # give a name to the anonymouse function so that we can call it

--- a/shim.js
+++ b/shim.js
@@ -5475,6 +5475,13 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
 
   pageWrap = function(page) {
     return mkwrap(page, ['open', 'close', 'includeJs', 'sendEvent', 'release', 'uploadFile', 'goBack', 'goForward', 'reload'], {
+      onConsoleMessage: function(fn, cb) {
+        if (cb == null) cb = (function() {});
+        page.onConsoleMessage = function() {
+          return fn.apply(this, arguments);
+        };
+        return cb();
+      },
       onResourceRequested: function(fn, cb) {
         if (cb == null) cb = (function() {});
         return page.onResourceRequested = function() {

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -121,7 +121,9 @@ describe "Pages",
 
           "which works correctly": (msg) ->
             assert.equal msg, "Hello, world!"
+        ###
 
+        ###
         "can register an onConsoleMessage handler":
           topic: t (page) ->
             page.set 'onConsoleMessage', (msg) =>
@@ -131,6 +133,15 @@ describe "Pages",
           "which works correctly": (msg) ->
             assert.equal msg, "Hello, world!"
         ###
+
+        "can register an onConsoleMessage handler":
+          topic: t (page) ->
+            page.onConsoleMessage (msg) =>
+              @callback null, msg
+            page.evaluate (-> console.log "Hello, world!")
+
+          "which works correctly": (msg) ->
+            assert.equal msg, "Hello, world!"
 
         "can render the page to a file":
           topic: t (page) ->


### PR DESCRIPTION
> Add `page.onConsoleMessage` instead of using `page.set('onConsoleMessage', function(){})`

Credit goes to @alexprobchansky for the solution.

Fixes #130, #125, #137. 
Do note that this does **not** _fix_ usage of `page.set('onConsoleMessage', function(){})` but instead provides an API that DOES work and passes an equivalent test (see test included).
## Before

``` javascript
var phantom;
phantom = require('phantom');
phantom.create(function(phantomInstance) {
  return phantomInstance.createPage(function(page) {
    return page.open("file.html", function() {
      // --- START, would crash here
      page.set('onConsoleMessage', function(msg) { console.log(msg); });
      // --- END
      page.evaluate(function() {
        return console.log("I will crash you fool!");
      });
      return phantomInstance.exit();
    });
  });
});
```
## After

``` javascript
var phantom;
phantom = require('phantom');
phantom.create(function(phantomInstance) {
  return phantomInstance.createPage(function(page) {
    return page.open("file.html", function() {
      // --- START, no longer crashes
      page.onConsoleMessage(function(msg) { console.log(msg); });
      // --- END
      page.evaluate(function() {
        return console.log("I will crash you fool!");
      });
      return phantomInstance.exit();
    });
  });
});
```
