### PR TITLE
Exposing the `ChildProcess` object. Fixes #176.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,6 +102,13 @@ You can also pass command line switches to the phantomjs process by specifying a
 phantom.create '--load-images=no', '--local-to-remote-url-access=yes', (page) ->
 ```
 
+If you need to access the [ChildProcess](http://nodejs.org/api/child_process.html#child_process_class_childprocess) of the phantom process to get its PID, for instance, you can access it through the `process` property like this:
+```
+phantom.create(function (ph) {
+  console.log('phantom process pid:', ph.process.pid);
+});
+```
+
 ##Note for Mac users
 
 Phantom requires you to have the XCode Command Line Tools installed on your box, or else you will get some nasty errors (`xcode` not found or `make` not found).  If you haven't already, simply install XCode through the App Store, then [install the command line tools](http://stackoverflow.com/questions/6767481/where-can-i-find-make-program-for-mac-os-x-lion).  

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -47,6 +47,7 @@ module.exports =
     options.port ?= 0
     options.dnodeOpts ?= {}
 
+    ps = null;
     phantom = null
 
     httpServer = http.createServer()
@@ -86,6 +87,7 @@ module.exports =
 
       d.on 'remote', (phantom) ->
         wrap phantom
+        phantom.process = ps
         phanta.push phantom
         cb? phantom
 

--- a/phantom.js
+++ b/phantom.js
@@ -61,7 +61,7 @@
 
   module.exports = {
     create: function() {
-      var arg, args, cb, httpServer, options, phantom, sock, _i, _len;
+      var arg, args, cb, httpServer, options, phantom, ps, sock, _i, _len;
       args = [];
       options = {};
       for (_i = 0, _len = arguments.length; _i < _len; _i++) {
@@ -86,11 +86,12 @@
       if (options.dnodeOpts == null) {
         options.dnodeOpts = {};
       }
+      ps = null;
       phantom = null;
       httpServer = http.createServer();
       httpServer.listen(options.port);
       httpServer.on('listening', function() {
-        var port, ps;
+        var port;
         port = httpServer.address().port;
         ps = startPhantomProcess(options.binary, port, args);
         ps.stdout.on('data', options.onStdout || function(data) {
@@ -138,6 +139,7 @@
         d = dnode({}, options.dnodeOpts);
         d.on('remote', function(phantom) {
           wrap(phantom);
+          phantom.process = ps;
           phanta.push(phantom);
           return typeof cb === "function" ? cb(phantom) : void 0;
         });


### PR DESCRIPTION
We need access to the PID as well as our app might crash and leave orphan phantomjs processes behind which we must clean up.

The fix is very simple. It exposes the resulting [ChildProcess](http://nodejs.org/api/child_process.html#child_process_class_childprocess) object as a property named `process`.
