### PR TITLE
We need close httpserver when trigger the error: don't have 'phantomjs' installed

### DIFF
--- a/phantom.js
+++ b/phantom.js
@@ -111,6 +111,7 @@
           return module.exports.stderrHandler(data.toString('utf8'));
         });
         ps.on('error', function(err) {
+          httpServer.close();
           if ((err != null ? err.code : void 0) === 'ENOENT') {
             return console.error("phantomjs-node: You don't have 'phantomjs' installed");
           } else {


### PR DESCRIPTION
when i didn't install phantomjs, it will trigger the error: don't have 'phantomjs' installed, and the program exit, I think the http server should close before program exit.
