### PR TITLE
Command-Line Parameters via Options Object

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,6 +120,12 @@ You can also pass command line switches to the phantomjs process by specifying a
 phantom.create '--load-images=no', '--local-to-remote-url-access=yes', (page) ->
 ```
 
+or by specifying them in the options object:
+
+```coffeescript
+phantom.create {parameters: {'load-images': 'no', 'local-to-remote-url-access': 'yes'}}, (page) ->
+```
+
 If you need to access the [ChildProcess](http://nodejs.org/api/child_process.html#child_process_class_childprocess) of the phantom process to get its PID, for instance, you can access it through the `process` property like this:
 ```
 phantom.create(function (ph) {

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -45,6 +45,9 @@ module.exports =
         when 'function' then cb = arg
         when 'string' then args.push arg
         when 'object' then options = arg
+    if typeof options.parameters is 'object'
+      for key, value of options.parameters
+        args.push '--'+key+'='+value
     options.path ?= ''
     options.binary ?= options.path+'phantomjs'
     options.port ?= 0

--- a/phantom.js
+++ b/phantom.js
@@ -64,7 +64,7 @@
 
   module.exports = {
     create: function() {
-      var arg, args, cb, httpServer, options, phantom, ps, sock, _i, _len;
+      var arg, args, cb, httpServer, key, options, phantom, ps, sock, value, _i, _len, _ref;
       args = [];
       options = {};
       for (_i = 0, _len = arguments.length; _i < _len; _i++) {
@@ -78,6 +78,13 @@
             break;
           case 'object':
             options = arg;
+        }
+      }
+      if (typeof options.parameters === 'object') {
+        _ref = options.parameters;
+        for (key in _ref) {
+          value = _ref[key];
+          args.push('--' + key + '=' + value);
         }
       }
       if (options.path == null) {
@@ -111,7 +118,6 @@
           return module.exports.stderrHandler(data.toString('utf8'));
         });
         ps.on('error', function(err) {
-          httpServer.close();
           if ((err != null ? err.code : void 0) === 'ENOENT') {
             return console.error("phantomjs-node: You don't have 'phantomjs' installed");
           } else {

--- a/test/adv.coffee
+++ b/test/adv.coffee
@@ -75,3 +75,24 @@ describe "The phantom module (adv)",
 
     "which loads on the correct port": (port) ->
       assert.equal port, 12301
+
+  "Can create an instance with load-images: no in an args object":
+    topic: t ->
+      phantom.create {parameters: {'load-images': 'no'}}, (ph) =>
+        @callback null, ph
+
+    "which, when you open a page":
+      topic: t (ph) ->
+        ph.createPage (page) =>
+          page.open "http://127.0.0.1:#{appServer.address().port}/", (status) =>
+            setTimeout =>
+              @callback null, page, status
+            , 1500
+
+      "and check the settings object":
+        topic: t (page, status) ->
+          page.get 'settings', (s) =>
+            @callback null, s
+
+        "loadImages isn't set": (s) ->
+          assert.strictEqual s.loadImages, false


### PR DESCRIPTION
Passing in command-line parameters via multiple string arguments does
not allow for a lot of flexibility in toggling parameters. This adds
a way to specify parameters in object notation on the options object.
