### PR TITLE
Added SetFileOnPicker method for onFilePicker (fixes #189)

### DIFF
--- a/shim.coffee
+++ b/shim.coffee
@@ -110,6 +110,10 @@ pageWrap = (page) -> mkwrap page,
   setPaperSize: (options, cb=->) ->
     page.paperSize = transform(options); cb()
   setZoomFactor: (zoomFactor, cb=->) -> page.zoomFactor = zoomFactor; cb()
+  setFileOnPicker: (fileName, cb=->) ->
+    page.onFilePicker = ->
+      cb.apply(this, arguments)
+      fileName
 
 _phantom = mkwrap phantom,
   ['exit'],

--- a/shim.js
+++ b/shim.js
@@ -5585,6 +5585,13 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
         if (cb == null) cb = function() {};
         page.zoomFactor = zoomFactor;
         return cb();
+      },
+      setFileOnPicker: function(fileName, cb) {
+        if (cb == null) cb = function() {};
+        return page.onFilePicker = function() {
+          cb.apply(this, arguments);
+          return fileName;
+        };
       }
     });
   };


### PR DESCRIPTION
Fixes #189 
Support for `onFilePicker` callback.
1. Passing a file name (first parameter) to `setFileOnPicker`  would register the filename on the callback `onFilePicker` to support upload of the file.
2. Second parameter is simply a callback with arguments passed from the `onFilePicker` callback.
