### PR TITLE
Can pass extra arguments to onResourceRequested which runs in phantomjs scope

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,11 +99,12 @@ Due to the async nature of the bridge, some things have changed, though:
 * ```page.render()``` takes a callback so you can tell when it's done writing the file
 * Properties can't be get/set directly, instead use ```page.get('version', callback)``` or ```page.set('viewportSize', {width:640,height:480})```, etc. Nested objects can be accessed by including dots in keys, such as ```page.set('settings.loadImages', false)```
 * Callbacks can't be set directly, instead use ```page.set('callbackName', callback)```, e.g. ```page.set('onLoadFinished', function(success) {})```
-* onResourceRequested takes a function that executes in the scope of phantom which has access to ```request.abort()```, ```request.changeUrl(url)```, and ```request.setHeader(key,value)```. The second argument is the callback which can execute in the scope of your code, with access to just the requestData. e.g.
+* onResourceRequested takes a function that executes in the scope of phantom which has access to ```request.abort()```, ```request.changeUrl(url)```, and ```request.setHeader(key,value)```. The second argument is the callback which can execute in the scope of your code, with access to just the requestData. This function can apply extra arguments which can be passed into the first function e.g.
 ```
 page.onResourceRequested(
-	function(requestData, request) { request.abort(); },
-	function(requestData) { console.log(requestData.url) }
+	function(requestData, request, arg1, arg2) { request.abort(); },
+	function(requestData) { console.log(requestData.url) },
+	arg1, arg2
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "phantom",
   "description": "PhantomJS wrapper for Node",
   "homepage": "https://github.com/sgentle/phantomjs-node",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/sgentle/phantomjs-node.git"

--- a/phantom.coffee
+++ b/phantom.coffee
@@ -33,7 +33,8 @@ wrap = (ph) ->
       page._evaluate = page.evaluate
       page.evaluate = (fn, cb, args...) -> page._evaluate.apply(page, [fn.toString(), cb].concat(args))
       page._onResourceRequested = page.onResourceRequested
-      page.onResourceRequested = (fn, cb) -> page._onResourceRequested.apply(page, [fn.toString(), cb])
+      # can apply extra args which will be passed to phantomjs onResourceRequested scope
+      page.onResourceRequested = (fn, cb, args...) -> page._onResourceRequested.apply(page, [fn.toString(), cb].concat(args))
       cb page
 
 module.exports =

--- a/phantom.js
+++ b/phantom.js
@@ -54,8 +54,10 @@
           return page._evaluate.apply(page, [fn.toString(), cb].concat(args));
         };
         page._onResourceRequested = page.onResourceRequested;
-        page.onResourceRequested = function(fn, cb) {
-          return page._onResourceRequested.apply(page, [fn.toString(), cb]);
+        page.onResourceRequested = function() {
+          var args, cb, fn;
+          fn = arguments[0], cb = arguments[1], args = 3 <= arguments.length ? __slice.call(arguments, 2) : [];
+          return page._onResourceRequested.apply(page, [fn.toString(), cb].concat(args));
         };
         return cb(page);
       });
@@ -118,6 +120,7 @@
           return module.exports.stderrHandler(data.toString('utf8'));
         });
         ps.on('error', function(err) {
+          httpServer.close();
           if ((err != null ? err.code : void 0) === 'ENOENT') {
             return console.error("phantomjs-node: You don't have 'phantomjs' installed");
           } else {

--- a/shim.coffee
+++ b/shim.coffee
@@ -75,16 +75,18 @@ pageWrap = (page) -> mkwrap page,
     page.onConsoleMessage = ->
       fn.apply(this, arguments)
     cb()
-  onResourceRequested: (fn, cb=(->)) ->
+  onResourceRequested: (fn, cb=(->), args...) ->
     page.onResourceRequested = ->
+      # prepare a arguments with the extra args
+      argumentsWithExtraArgs = [].slice.apply(arguments).concat(args)
       # give a name to the anonymouse function so that we can call it
       fn = fn.replace /function.*\(/, 'function x('
       # the only way we can access the request object is by passing a function to this point as a string and expanding it
       eval(fn) # :(
       # this function has access to request.abort()
-      x.apply(this, arguments)
+      x.apply(this, argumentsWithExtraArgs)
       # this function does not have access to request.abort()
-      cb.apply(this, arguments)
+      cb.apply(this, argumentsWithExtraArgs)
   injectJs: (js, cb=->) -> cb page.injectJs js
   evaluate: (fn, cb=(->), args...) -> cb page.evaluate.apply(page, [fn].concat(args))
   render: (file, opts={}, cb) ->

--- a/shim.js
+++ b/shim.js
@@ -5511,13 +5511,17 @@ require.define("/shim.coffee", function (require, module, exports, __dirname, __
         };
         return cb();
       },
-      onResourceRequested: function(fn, cb) {
+      onResourceRequested: function() {
+        var args, cb, fn;
+        fn = arguments[0], cb = arguments[1], args = 3 <= arguments.length ? __slice.call(arguments, 2) : [];
         if (cb == null) cb = (function() {});
         return page.onResourceRequested = function() {
+          var argumentsWithExtraArgs;
+          argumentsWithExtraArgs = [].slice.apply(arguments).concat(args);
           fn = fn.replace(/function.*\(/, 'function x(');
           eval(fn);
-          x.apply(this, arguments);
-          return cb.apply(this, arguments);
+          x.apply(this, argumentsWithExtraArgs);
+          return cb.apply(this, argumentsWithExtraArgs);
         };
       },
       injectJs: function(js, cb) {


### PR DESCRIPTION
Currently, it is impossible to pass any arguments to the first arguments of `page.onResourceRequested`.

With this commit, when we define `page.onResourceRequested`, we can pass more than 2 arguments to the function, the extra ones(from the 3rd) will be passed to the function which can access `request.abort()` as the extra parameters.

The code should look like:

```
page.onResourceRequested(
    function(requestData, request, arg1, arg2, arg3) {
        request.abort();
        console.log(arg1, arg2, arg3); //success! 
    },
    function(requestData) { },
    arg1, arg2, arg3
);
```

BTW, this won't break any existing code.
