### PR TITLE
Code Doesn't match documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,7 +113,7 @@ page.onResourceRequested(
 
 Also, you can set exit callback, which would be invoked after ```phantom.exit()``` or after phantom process crash:
 ```
-phantom.create('flags', { port: 8080, onExit: exitCallback})
+phantom.create({ port: 8080, onExit: exitCallback}, createCallback)
 ```
 
 You can also pass command line switches to the phantomjs process by specifying additional args to ```phantom.create()```, eg:


### PR DESCRIPTION
Hey guys, 

I used the flag syntax from the doc to prevent parent process from exiting on segfault, but it doesn't work, looks like it just wants an object. 

Error:

Jan 23 00:14:05 vagrant-ubuntu-trusty-64 ts-cs[8373]: [/node_modules/phantom/phantom.js:181] phantom stderr: Can't open 'flags'

Code:
```
create: ->
  args = []
  options = {}
  for arg in arguments
    switch typeof arg
      when 'function' then cb = arg
      when 'string' then args.push arg
      when 'object' then options = arg
  if typeof options.parameters is 'object'
    for key, value of options.parameters
      args.push '--'+key+'='+value
  options.path ?= ''
  options.binary ?= options.path+'phantomjs'
  options.port ?= 0
  options.hostname ?= ‘localhost’
```