### PR TITLE
Prevent blocking reads from clogging event-queue.

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -93,7 +93,8 @@ function executeCommand(command) {
 
 function completeCommand(command) {
     system.stdout.writeLine('>' + JSON.stringify(command));
-    read();
+    // Prevent event-queue from clogging up by reads that block.
+    setTimeout(read, 0);
 }
 
 read();


### PR DESCRIPTION
### Proposed changes in this pull request

Continuous reads prevent the event-queue from processing JavaScript on the webpage (including DOM changes). 

#### Checklist
* [ ] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

