### PR TITLE
Fixes #383 by adding proxy around callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Make sure to call `#exit()` on the phantom instance to kill the phantomjs proces
 
   The `page` object that is returned with `#createPage` is a proxy that sends all methods to `phantom`. Most method calls should be identical to PhantomJS API. You must remember that each method returns a `Promise`.
 
+### `page#setting`
+
+`page.settings` can be accessed via `page.setting(key)` or set via `page.setting(key, value)`. Here is an example to read `javascriptEnabled` property.
+
+```js
+page.setting('javascriptEnabled').then(function(value){
+    expect(value).toEqual(true);
+});
+```
+
+### `page#property`
+
+
   Page properties can be read using the `#property(key)` method.
 
   ```js
@@ -86,21 +99,24 @@ page.property('viewportSize', {width: 800, height: 600}).then(function() {
   ```
 When setting values, using `then()` is optional. But beware that the next method to phantom will block until it is ready to accept a new message.
 
-`page.settings` can be accessed via `page.setting(key)` or set via `page.setting(key, value)`. Here is an example to read `javascriptEnabled` property.
-
-```js
-page.setting('javascriptEnabled').then(function(value){
-    expect(value).toEqual(true);
-});
-```
-
 You can set events using `#property()` because they are property members of `page`.
 
 ```js
 page.property('onResourceRequested', function(requestData, networkRequest) {
     console.log(requestData.url);
-})
+});
 ```
+It is important to understand that the function above executes in the PhantomJS process. PhantomJS does not share any memory or variables with node. So using closures in javascript to share any variables outside of the function is not possible. Variables can be passed to `#property` instead. So for example, let's say you wanted to pass `process.env.DEBUG` to `onResourceRequested` method above. You could this by:
+
+```js
+page.property('onResourceRequested', function(requestData, networkRequest, debug) {
+    if(debug){
+      // do something with it
+    }
+}, process.env.DEBUG);
+```
+
+### `page#evaluate`
 
 Using `#evaluate()` is similar to passing a function above. For example, to return HTML of an element you can do:
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -33,8 +33,19 @@ const commands = {
         }
     },
     property: command => {
-        if (command.params.length === 2) {
-            objectSpace[command.target][command.params[0]] = command.params[1];
+        if (command.params.length > 1) {
+            if (typeof command.params[1] === 'function') {
+                // If the second parameter is a function then we want to proxy and pass parameters too
+                let callback = command.params[1];
+                let args = command.params.slice(2);
+                objectSpace[command.target][command.params[0]] = function () {
+                    let params = [].slice.call(arguments).concat(args);
+                    return callback.apply(objectSpace[command.target], params);
+                };
+            } else {
+                // If the second parameter is not a function then just assign
+                objectSpace[command.target][command.params[0]] = command.params[1];
+            }
         } else {
             command.response = objectSpace[command.target][command.params[0]];
         }
@@ -57,7 +68,6 @@ const commands = {
         } else {
             command.response = window[command.params[0]];
         }
-        
         completeCommand(command);
     },
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -48,6 +48,17 @@ describe('Page', () => {
         expect(content).toEqual('hi, /foo-bar-xyz'); // should have been changed to /foo-bar-xyz
     });
 
+    it('#property(\'onResourceRequested\', function(){}, params...) passes parameters', function*() {
+        let page = yield phantom.createPage();
+        page.property('onResourceRequested', (requestData, networkRequest, foo, a, b) => {
+            RESULT = [foo, a, b];
+        }, 'foobar', 1, -100);
+        yield page.open('http://localhost:8888/whatever');
+
+        let RESULT = yield phantom.windowProperty('RESULT');
+        expect(RESULT).toEqual(['foobar', 1, -100]);
+    });
+
     it('#property(\'key\', value) sets property', function*() {
         let page = yield phantom.createPage();
         yield page.property('viewportSize', {width: 800, height: 600});


### PR DESCRIPTION
### Proposed changes in this pull request

```js
var phantom = require('phantom');

phantom.create().then(function(ph) {
    ph.createPage().then(function(page) {
        var test = 123;
        var property2 = 'foobar';

        page.property('onResourceRequested', function(requestData, request, a, b, c) {
            console.log(requestData.id, a, b, c);
        }, test, property2, {fooBar: true});

        page.open('http://amirraminfar.com', function(status) {
            ph.exit();
        });
    });
});
```
makes it so the above is possible. 

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review

