### PR TITLE
Add page.setContent command

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -11,7 +11,7 @@ export default class Page {
 
 const methods = [
     'open', 'render', 'close', 'property', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
-    'evaluate', 'setting', 'addCookie', 'deleteCookie', 'clearCookies'
+    'evaluate', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent'
 ];
 
 methods.forEach(method => {

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -235,5 +235,18 @@ describe('Page', () => {
         let lastResponse = yield phantom.windowProperty('lastResponse');
         expect(lastResponse.url).toEqual('http://localhost:8888/test');
     });
+
+    it('#setContent() works with custom url', function*() {
+        let page = yield phantom.createPage();
+        let html = '<html><head><title>setContent Title</title></head><body></body></html>';
+
+        yield page.setContent(html, 'http://localhost:8888/');
+
+        let response = yield page.evaluate(function () {
+            return [document.title, location.href];
+        });
+
+        expect(response).toEqual(['setContent Title', 'http://localhost:8888/']);
+    });
 });
 


### PR DESCRIPTION
### Proposed changes in this pull request

Add setContent command, test both content and URL in page_spec.
We need it since setContent can't be replaced by property('content') because property('url') is read only.
No docs since it already says “most method calls”.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review
