### PR TITLE
Adding sendEvent method to the page object

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -11,7 +11,7 @@ export default class Page {
 
 const methods = [
     'open', 'render', 'close', 'property', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
-    'evaluate', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent'
+    'evaluate', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent'
 ];
 
 methods.forEach(method => {

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -2,6 +2,7 @@ import phantomjs from "phantomjs-prebuilt";
 import {spawn} from "child_process";
 import winston from "winston";
 import os from "os";
+import path from "path";
 import Linerstream from "linerstream";
 import Page from "./page";
 import Command from "./command";
@@ -30,8 +31,9 @@ export default class Phantom {
             throw new Error('Unexpected type of parameters. Expecting args to be array.');
         }
 
-        logger.debug(`Starting ${phantomjs.path} ${args.concat([__dirname + '/shim.js']).join(' ')}`);
-        this.process = spawn(phantomjs.path, args.concat([__dirname + '/shim.js']));
+        let pathToShim = path.normalize(__dirname + '/shim.js');
+        logger.debug(`Starting ${phantomjs.path} ${args.concat([pathToShim]).join(' ')}`);
+        this.process = spawn(phantomjs.path, args.concat([pathToShim]));
         this.commands = new Map();
 
         this.process.stdin.setEncoding('utf-8');

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -248,5 +248,21 @@ describe('Page', () => {
 
         expect(response).toEqual(['setContent Title', 'http://localhost:8888/']);
     });
+	
+	
+    it('#sendEvent() sends an event', function*() {
+        let page = yield phantom.createPage();
+        let html = '<html  onclick="docClicked = true;"><head><title>setContent Title</title></head><body></body></html>';
+
+        yield page.setContent(html, 'http://localhost:8888/');
+        yield page.sendEvent('click', 1, 2);
+
+        let response = yield page.evaluate(function () {
+            return window.docClicked;
+        });
+
+        expect(response).toEqual(true);
+    });
+
 });
 


### PR DESCRIPTION
### Proposed changes in this pull request

Adds the sendEvent method to the page object, and requisite test

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully - see below
* [ ] Documentation has been updated

Note on the tests for me I was getting 2 failures with the existing tests (i.e. before adding any new code)

```
Failures:
1) Phantom #create([]) execute with no parameters
1.1) Expected spy spawn to have been called with [ 'C:\wwwroot\phantomjs-node\node_modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe', [ 'C:\wwwroot\phantomjs-node\lib\shim.js' ] ] but actual calls were [ 'C:\wwwroot\phantomjs-node\node_modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe', [ 'C:\wwwroot\phantomjs-node\lib/shim.js' ] ].

2) Phantom #create(["--ignore-ssl-errors=yes"]) adds parameter to process
2.1) Expected spy spawn to have been called with [ 'C:\wwwroot\phantomjs-node\node_modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe', [ '--ignore-ssl-errors=yes', 'C:\wwwroot\phantomjs-node\lib\shim.js' ] ] but actual calls were [ 'C:\wwwroot\phantomjs-node\node_modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe', [ '--ignore-ssl-errors=yes', 'C:\wwwroot\phantomjs-node\lib/shim.js' ] ].
```

Looks like its an OS pathing issue (I'm on a windows machine), updated the the pull request to fix that issue (normalizing the path in shim.js)

@amir20 to review
