### PR TITLE
Adds OutObject to be able to pass data back in to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ page.property('onResourceRequested', function(requestData, networkRequest, debug
 }, process.env.DEBUG);
 ```
 
+You can return data to NodeJS by using `#createOutObject()`. This is a special object that let's you write data in PhantomJS and read it in NodeJS. Using the example above, data can be read like:
+
+```js
+var outObj = phantom.createOutObject();
+page.property('onResourceRequested', function(requestData, networkRequest, debug, out) {
+    if(debug){      
+      out.url = requestData.url;
+    }
+}, process.env.DEBUG, outObj);
+
+outObj.property('url').then(function(url){
+   console.log(url);
+});
+
+```
+
 ### `page#evaluate`
 
 Using `#evaluate()` is similar to passing a function above. For example, to return HTML of an element you can do:

--- a/src/out_object.js
+++ b/src/out_object.js
@@ -1,0 +1,13 @@
+import crypto from "crypto";
+
+
+export default class OutObject {
+    constructor(phantom) {
+        this._phantom = phantom;
+        this.target = 'OutObject$' + crypto.randomBytes(16).toString('hex');
+    }
+
+    property(name) {
+        return this._phantom.execute(this.target, 'property', [name]);
+    }
+}

--- a/src/shim.js
+++ b/src/shim.js
@@ -33,6 +33,11 @@ const commands = {
                 // If the second parameter is a function then we want to proxy and pass parameters too
                 let callback = command.params[1];
                 let args = command.params.slice(2);
+                args.forEach(param => {
+                    if (param.target !== undefined) {
+                        objectSpace[param.target] = param;
+                    }
+                });
                 objectSpace[command.target][command.params[0]] = function () {
                     let params = [].slice.call(arguments).concat(args);
                     return callback.apply(objectSpace[command.target], params);
@@ -82,7 +87,6 @@ function read() {
                 var endBody = value.lastIndexOf('}');
                 var startArgs = value.indexOf('(') + 1;
                 var endArgs = value.indexOf(')');
-
                 return new Function(value.substring(startArgs, endArgs), value.substring(startBody, endBody));
             }
             return value;
@@ -114,7 +118,7 @@ function executeCommand(command) {
             completeCommand(command);
         } else {
             let params = command.params.slice(); // copy params
-            params.push((status) => {
+            params.push(status => {
                 command.response = status;
                 completeCommand(command);
             });

--- a/src/spec/out_object_spec.js
+++ b/src/spec/out_object_spec.js
@@ -1,0 +1,72 @@
+import http from "http";
+import Phantom from "../phantom";
+import "babel-polyfill";
+import OutObject from "../out_object";
+
+require('jasmine-co').install();
+
+describe('Command', () => {
+    let server;
+    let phantom;
+    beforeAll(done => {
+        server = http.createServer((request, response) => response.end('hi, ' + request.url));
+        server.listen(8888, done);
+    });
+
+    afterAll(() => server.close());
+    beforeEach(() => phantom = new Phantom());
+    afterEach(() => phantom.exit());
+
+    it('target to be set', () => {
+        expect(phantom.createOutObject().target).toEqual(jasmine.any(String));
+    });
+
+    it('#createOutObject() is a valid OutObject', () => {
+        let outObj = phantom.createOutObject();
+        expect(outObj).toEqual(jasmine.any(OutObject));
+    });
+
+    it('#property() returns a value set by phantom', function*() {
+        let page = yield phantom.createPage();
+        let outObj = phantom.createOutObject();
+
+        yield page.property('onResourceReceived', function (response, out) {
+            out.lastResponse = response;
+        }, outObj);
+
+        yield page.open('http://localhost:8888/test');
+
+        let lastResponse = yield outObj.property('lastResponse');
+
+        expect(lastResponse.url).toEqual('http://localhost:8888/test');
+    });
+
+    it('#property() returns a value set by phantom and node', function*() {
+        let page = yield phantom.createPage();
+        let outObj = phantom.createOutObject();
+
+        outObj.test = 'fooBar$';
+
+        yield page.property('onResourceReceived', function (response, out) {
+            out.data = out.test + response.url;
+        }, outObj);
+
+        yield page.open('http://localhost:8888/test2');
+        let data = yield outObj.property('data');
+        expect(data).toEqual('fooBar$http://localhost:8888/test2');
+    });
+
+    it('#property() works with input params', function*() {
+        let page = yield phantom.createPage();
+        let outObj = phantom.createOutObject();
+
+
+        yield page.property('onResourceReceived', function (response, test, out) {
+            out.data = test;
+        }, 'test', outObj);
+
+        yield page.open('http://localhost:8888/test2');
+        let data = yield outObj.property('data');
+        expect(data).toEqual('test');
+    });
+});


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request add functionality to pass data back into node. Here is sample code:

```js

var reqPageUrl = 'http://amirraminfar.com/';

var phantom = require('phantom');

phantom.create().then(function(ph) {
    ph.createPage().then(function(page) {

        var outObj = ph.createOutObject(); // <-- use this special object to return data back to node

        page.property('onResourceReceived', function(resource, reqPageUrl, out) {
            if (resource.url === reqPageUrl) {
                console.log('resource.url', resource.url);
                out.url = resource.status;
            }
        }, reqPageUrl, outObj).then(function() {
            return page.open(reqPageUrl);
        }).then(function(status) {
            console.log('status', status);
            return outObj.property('url');
        }).then(function(url) {
            console.log('url', url);
            ph.exit();
        }).catch(function(e) {
            console.error(e)
        });
    });
});

```
#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review

