### PR TITLE
Changed 'phantom' to 'phInstance', because 'phantom' does not have 'c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ page.property('onResourceRequested', function(requestData, networkRequest, debug
 You can return data to NodeJS by using `#createOutObject()`. This is a special object that let's you write data in PhantomJS and read it in NodeJS. Using the example above, data can be read by doing:
 
 ```js
-var outObj = phantom.createOutObject();
+var outObj = phInstance.createOutObject();
 page.property('onResourceRequested', function(requestData, networkRequest, debug, out) {
     if(debug){      
       out.url = requestData.url;


### PR DESCRIPTION
### Proposed changes in this pull request

Changed 'phantom' to 'phInstance', because 'phantom' does not have 'createOutObject' method

#### Checklist
* [ ] New tests have been added
* [ ] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review

…reateOutObject' method