### PR TITLE
Made that page events could be run in node runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ page.property('viewportSize', {width: 800, height: 600}).then(function() {
   ```
 When setting values, using `then()` is optional. But beware that the next method to phantom will block until it is ready to accept a new message.
 
-You can set events using `#property()` because they are property members of `page`.
+You can set events using `#property()` because they are property members of `page.
 
 ```js
 page.property('onResourceRequested', function(requestData, networkRequest) {
@@ -129,6 +129,8 @@ page.property('onResourceRequested', function(requestData, networkRequest, debug
     }
 }, process.env.DEBUG);
 ```
+Even if it is possible to set the events using this way, we recommend you use `#on()` for events (see below).
+
 
 You can return data to NodeJS by using `#createOutObject()`. This is a special object that let's you write data in PhantomJS and read it in NodeJS. Using the example above, data can be read by doing:
 
@@ -145,6 +147,42 @@ outObj.property('urls').then(function(urls){
 });
 
 ```
+
+### `page#on`
+
+By using `on(event, [runOnPhantom=false],listener, args*)`, you can listen to the events the events the page emits.
+
+```js
+var urls = [];
+
+page.on('onResourceRequested', function (requestData, networkRequest) {
+    urls.push(requestData.url); // this would push the url into the urls array above
+    networkRequest.abort(); // This will fail, because the params are a serialized version of what was provided
+});
+
+page.load('http://google.com');
+```
+As you see, using on you have access to the closure variables and all the node goodness using this function ans in contrast of setting and event with property, you can set as many events as you want.
+
+If you want to register a listener to run in phantomjs runtime (and thus, be able to cancel the request lets say), you can make it by passing the optional param `runOnPhantom` as `true`;
+
+```js
+var urls = [];
+
+page.on('onResourceRequested', true, function (requestData, networkRequest) {
+    urls.push(requestData.url); // now this wont work, because this function would exercute in phantom runtime and thus wont have acces to the closure.
+    networkRequest.abort(); // This would work, because you are accessing to the non serialized networkRequest.
+});
+
+page.load('http://google.com');
+```
+The same as in property, you can pass additional params to the function in the same way, and even use the object created by `#createOutObject()`.
+
+You cannot use `#property()` and `#on()` at the same time, because it would conflict. Property just sets the function in phantomjs, while `#on()` manages the event in a different way.
+
+### `age#off`
+
+`#of(event)` is usefull to remove all the event listeners set by `#on()` for ans specific event.
 
 ### `page#evaluate`
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "phantom",
   "description": "PhantomJS integration module for NodeJS",
   "homepage": "https://github.com/amir20/phantomjs-node",
-  "version": "2.0.10",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/amir20/phantomjs-node.git"

--- a/src/page.js
+++ b/src/page.js
@@ -8,13 +8,21 @@ export default class Page {
     }
 
     on(event, runOnPhantom, callback) {
+        let mustRunOnPhantom;
+        let listener;
+        let args;
+
         if (typeof runOnPhantom === 'function') {
-            let args = [].slice.call(arguments, 2);
-            return this.phantom.on(event, this.target, false, runOnPhantom.bind(this), args);
+            args = [].slice.call(arguments, 2);
+            mustRunOnPhantom = false;
+            listener = runOnPhantom.bind(this);
         } else {
-            let args = [].slice.call(arguments, 3);
-            return this.phantom.on(event, this.target, runOnPhantom, runOnPhantom ? callback : callback.bind(this), args);
+            args = [].slice.call(arguments, 3);
+            mustRunOnPhantom = runOnPhantom;
+            listener = mustRunOnPhantom ? callback : callback.bind(this)
         }
+
+        return this.phantom.on(event, this.target, mustRunOnPhantom, listener, args);
     }
 
     off(event) {

--- a/src/page.js
+++ b/src/page.js
@@ -6,6 +6,20 @@ export default class Page {
         this.target = 'page$' + pageId;
         this.phantom = phantom;
     }
+
+    on(event, runOnPhantom, callback) {
+        if (typeof runOnPhantom === 'function') {
+            let args = [].slice.call(arguments, 2);
+            return this.phantom.on(event, this.target, false, runOnPhantom.bind(this), args);
+        } else {
+            let args = [].slice.call(arguments, 3);
+            return this.phantom.on(event, this.target, runOnPhantom, runOnPhantom ? callback : callback.bind(this), args);
+        }
+    }
+
+    off(event) {
+        return this.phantom.off(event, this.target);
+    }
 }
 
 

--- a/src/page.js
+++ b/src/page.js
@@ -7,24 +7,39 @@ export default class Page {
         this.phantom = phantom;
     }
 
-    on(event, runOnPhantom, callback) {
+    /**
+     * Add an event listener to the page on phantom
+     *
+     * @param event The name of the event (Ej. onResourceLoaded)
+     * @param [runOnPhantom=false] Indicate if the event must run on the phantom runtime or not
+     * @param listener The event listener. When runOnPhantom=true, this listener code would be run on phantom, and thus,
+     * all the closure info wont work
+     * @returns {*}
+     */
+    on(event, runOnPhantom, listener) {
         let mustRunOnPhantom;
-        let listener;
+        let callback;
         let args;
 
         if (typeof runOnPhantom === 'function') {
             args = [].slice.call(arguments, 2);
             mustRunOnPhantom = false;
-            listener = runOnPhantom.bind(this);
+            callback = runOnPhantom.bind(this);
         } else {
             args = [].slice.call(arguments, 3);
             mustRunOnPhantom = runOnPhantom;
-            listener = mustRunOnPhantom ? callback : callback.bind(this)
+            callback = mustRunOnPhantom ? listener : listener.bind(this)
         }
 
-        return this.phantom.on(event, this.target, mustRunOnPhantom, listener, args);
+        return this.phantom.on(event, this.target, mustRunOnPhantom, callback, args);
     }
 
+    /**
+     * Removes an event listener
+     *
+     * @param event the event name
+     * @returns {*}
+     */
     off(event) {
         return this.phantom.off(event, this.target);
     }

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -55,7 +55,7 @@ export default class Phantom {
                     deferred.reject(new Error(command.error));
                 }
                 this.commands.delete(command.id);
-            } else if (message.indexOf('<event>') !== -1) {
+            } else if (message.indexOf('<event>') === 0) {
                 let json = message.substr(7);
                 logger.debug('Parsing: %s', json);
                 const event = JSON.parse(json);

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -7,6 +7,7 @@ import Linerstream from "linerstream";
 import Page from "./page";
 import Command from "./command";
 import OutObject from "./out_object";
+import EventEmitter from 'events';
 
 const logger = new winston.Logger({
     transports: [
@@ -36,6 +37,7 @@ export default class Phantom {
         logger.debug(`Starting ${phantomjs.path} ${args.concat([pathToShim]).join(' ')}`);
         this.process = spawn(phantomjs.path, args.concat([pathToShim]));
         this.commands = new Map();
+        this.events = new Map();
 
         this.process.stdin.setEncoding('utf-8');
 
@@ -53,10 +55,20 @@ export default class Phantom {
                     deferred.reject(new Error(command.error));
                 }
                 this.commands.delete(command.id);
+            } else if (message.indexOf('<event>') !== -1) {
+                let json = message.substr(7);
+                logger.debug('Parsing: %s', json);
+                const event = JSON.parse(json);
+
+                var emitter = this.events[event.target];
+                if (emitter) {
+                    emitter.emit.apply(emitter, [event.type].concat(event.args));
+                }
             } else {
                 logger.info(message);
             }
         });
+
 
         this.process.stderr.on('data', data => logger.error(data.toString('utf8')));
         this.process.on('exit', code => logger.debug(`Child exited with code {${code}}`));
@@ -145,6 +157,51 @@ export default class Phantom {
      */
     execute(target, name, args = []) {
         return this.executeCommand(new Command(null, target, name, args));
+    }
+
+    /**
+     * Adds an event listener to a target object (currently only works on pages)
+     *
+     * @param event the event type
+     * @param target target object to execute against
+     * @param runOnPhantom would the callback run in phanthomjs or not
+     * @param callback the event callback
+     * @param args an array of args to pass to the callback
+     */
+    on(event, target, runOnPhantom, callback, args = []) {
+        var eventDescriptor = {type: event};
+
+        if (runOnPhantom) {
+            eventDescriptor.event = callback;
+            eventDescriptor.args = args;
+        } else {
+            var emitter = this.getEmitterForTarget(target);
+            emitter.on(event, function () {
+                let params = [].slice.call(arguments).concat(args);
+                return callback.apply(null, params);
+            });
+        }
+        return this.execute(target, 'addEvent', [eventDescriptor]);
+    }
+
+    /**
+     * Removes an event from a target object
+     *
+     * @param event
+     * @param target
+     */
+    off(event, target) {
+        var emitter = this.getEmitterForTarget(target);
+        emitter.removeAllListeners(event);
+        return this.execute(target, 'removeEvent', [{type: event}]);
+    }
+
+    getEmitterForTarget(target) {
+        if (!this.events[target]) {
+            this.events[target] = new EventEmitter();
+        }
+
+        return this.events[target];
     }
 
     /**

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -164,7 +164,7 @@ export default class Phantom {
      *
      * @param event the event type
      * @param target target object to execute against
-     * @param runOnPhantom would the callback run in phanthomjs or not
+     * @param runOnPhantom would the callback run in phantomjs or not
      * @param callback the event callback
      * @param args an array of args to pass to the callback
      */

--- a/src/shim.js
+++ b/src/shim.js
@@ -290,11 +290,7 @@ function triggerEvent(target, eventName) {
 function getOutsideListener(eventName, targetId) {
     return function () {
         var args = [].slice.call(arguments, 0);
-        system.stdout.writeLine('<event>' + JSON.stringify({
-            target: targetId,
-            type: eventName,
-            args
-        }));
+        system.stdout.writeLine('<event>' + JSON.stringify({target: targetId, type: eventName, args}));
     };
 }
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -8,6 +8,26 @@ const objectSpace = {
     phantom: phantom
 };
 
+const events = {};
+
+const eventsForEntities = {
+    page: [
+        'onInitialized',
+        'onLoadStarted',
+        'onLoadFinished',
+        'onUrlChanged',
+        'onNavigationRequested',
+        'onRepaintRequested',
+        'onResourceRequested',
+        'onResourceReceived',
+        'onResourceError',
+        'onResourceTimeout',
+        'onAlert',
+        'onConsoleMessage',
+        'onClosing'
+    ]
+};
+
 /**
  * All methods that have a callback in their signature
  * @type {string[]}
@@ -33,11 +53,7 @@ const commands = {
                 // If the second parameter is a function then we want to proxy and pass parameters too
                 let callback = command.params[1];
                 let args = command.params.slice(2);
-                args.forEach(param => {
-                    if (param.target !== undefined) {
-                        objectSpace[param.target] = param;
-                    }
-                });
+                syncOutObjects(args);
                 objectSpace[command.target][command.params[0]] = function () {
                     let params = [].slice.call(arguments).concat(args);
                     return callback.apply(objectSpace[command.target], params);
@@ -122,6 +138,19 @@ function transform(object) {
 }
 
 /**
+ * Sync all OutObjects present in the array
+ *
+ * @param objects
+ */
+function syncOutObjects(objects) {
+    objects.forEach(param => {
+        if (param.target !== undefined) {
+            objectSpace[param.target] = param;
+        }
+    });
+}
+
+/**
  * Executes a command by first checking if it is a custom method and then calling the method on the target.
  * @param command the command to execute
  */
@@ -132,7 +161,13 @@ function executeCommand(command) {
         const target = objectSpace[command.target];
         const method = target[command.name];
 
-        if (haveCallbacks.indexOf(command.name) === -1) {
+        if (command.name === 'addEvent') {
+            addEvent(command.target, command.params[0].type, command.params[0].event, command.params[0].args);
+            completeCommand(command);
+        } else if (command.name === 'removeEvent') {
+            removeEvent(command.target, command.params[0].type);
+            completeCommand(command);
+        } else if (haveCallbacks.indexOf(command.name) === -1) {
             command.response = method.apply(target, command.params);
             completeCommand(command);
         } else {
@@ -147,6 +182,122 @@ function executeCommand(command) {
         throw new Error(`Cannot find ${command.name} method to execute on ${command.target} object.`);
     }
 }
+
+/**
+ * Adds an event to the target
+ *
+ * @param target the id of the object to listen
+ * @param eventName the name off the event
+ * @param callback the callback of the event
+ * @param args the additional arguments for the callback
+ */
+function addEvent(target, eventName, callback, args) {
+    let type = getTargetType(target);
+
+    if (isEventSupported(type, eventName)) {
+        let listeners = getEventListeners(target, eventName);
+
+        if (typeof callback === 'function') {
+            listeners.otherListeners.push(function () {
+                let params = [].slice.call(arguments).concat(args);
+                return callback.apply(objectSpace[target], params);
+            });
+        }
+    }
+}
+
+/**
+ * Removes all the listeners for an event in a target
+ *
+ * @param target the id of the target
+ * @param eventName the name of the event
+ */
+function removeEvent(target, eventName) {
+    let type = getTargetType(target);
+
+    if (isEventSupported(type, eventName)) {
+        events[target][eventName] = null;
+        objectSpace[target][eventName] = null;
+    }
+}
+
+/**
+ * Verifies if an event is supported for a type of target
+ *
+ * @param type
+ * @param eventName
+ * @returns {boolean}
+ */
+function isEventSupported(type, eventName) {
+    return eventsForEntities[type] && eventsForEntities[type].indexOf(eventName) !== -1;
+}
+
+/**
+ * Gets an object containing all the listeners for an event of a target
+ *
+ * @param target the target id
+ * @param eventName the event name
+ */
+function getEventListeners(target, eventName) {
+    if (!events[target]) {
+        events[target] = {};
+    }
+
+    if (!events[target][eventName]) {
+        events[target][eventName] = {
+            outsideListener: getOutsideListener(eventName, target),
+            otherListeners: []
+        };
+
+        objectSpace[target][eventName] = triggerEvent.bind(null, target, eventName);
+    }
+
+    return events[target][eventName];
+}
+
+/**
+ * Determines a targets type using its id
+ *
+ * @param target
+ * @returns {*}
+ */
+function getTargetType(target) {
+    return target.toString().split('$')[0];
+}
+
+/**
+ * Executes all the listeners for an event from a target
+ *
+ * @param target
+ * @param eventName
+ */
+function triggerEvent(target, eventName) {
+    let args = [].slice.call(arguments, 2);
+    let listeners = events[target][eventName];
+    listeners.outsideListener.apply(null, args);
+    listeners.otherListeners.forEach(function (listener) {
+        listener.apply(objectSpace[target], args);
+    });
+}
+
+/**
+ * Returns a function that will notify to node that an event have been triggered
+ *
+ * @param eventName
+ * @param targetId
+ * @returns {Function}
+ */
+function getOutsideListener(eventName, targetId) {
+    return function () {
+        var args = [].slice.call(arguments, 0);
+        system.stdout.writeLine('<event>' + JSON.stringify({
+            target: targetId,
+            type: eventName,
+            args
+        }));
+    };
+}
+
 
 /**
  * Completes a command by return a response to node and listening again for next command.

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -370,28 +370,27 @@ describe('Page', () => {
 
         yield page.on('onLoadFinished', true, function () {
             runnedHere = true;
-            this.runnedInPhantomRuntime = true;
+            runnedInPhantomRuntime = true;
         });
 
         yield page.open('http://localhost:8888/test');
 
-        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+        let runnedInPhantomRuntime = yield phantom.windowProperty('runnedInPhantomRuntime');
 
         expect(runnedHere).toBe(false);
-        expect(runnedOnPhantomRuntime).toBe(true);
+        expect(runnedInPhantomRuntime).toBe(true);
     });
 
     it('#on() can pass parameters to functions to be executed in phantom runtime', function* () {
-        //failing
         let page = yield phantom.createPage();
 
         yield page.on('onResourceReceived', true, function (status, param) {
-            this.parameterProvided = param;
+            parameterProvided = param;
         }, 'param');
 
         yield page.open('http://localhost:8888/test');
 
-        let parameterProvided = yield page.property('parameterProvided');
+        let parameterProvided = yield phantom.windowProperty('parameterProvided');
 
         expect(parameterProvided).toBe('param');
     });
@@ -400,12 +399,12 @@ describe('Page', () => {
         let page = yield phantom.createPage();
 
         yield page.on('onResourceReceived', true, function () {
-            this.runnedInPhantomRuntime = true;
+            runnedInPhantomRuntime = true;
         });
 
-        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+        let runnedInPhantomRuntime = yield phantom.windowProperty('runnedInPhantomRuntime');
 
-        expect(runnedOnPhantomRuntime).toBeFalsy();
+        expect(runnedInPhantomRuntime).toBeFalsy();
     });
 
     it('#on() can register at the same event to run locally or in phantom runtime', function* () {
@@ -413,7 +412,7 @@ describe('Page', () => {
         let runnedHere = false;
 
         yield page.on('onResourceReceived', true, function () {
-            this.runnedInPhantomRuntime = true;
+            runnedInPhantomRuntime = true;
         });
 
         yield page.on('onResourceReceived', function () {
@@ -422,10 +421,10 @@ describe('Page', () => {
 
         yield page.open('http://localhost:8888/test');
 
-        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+        let runnedInPhantomRuntime = yield phantom.windowProperty('runnedInPhantomRuntime');
 
         expect(runnedHere).toBe(true);
-        expect(runnedOnPhantomRuntime).toBe(true);
+        expect(runnedInPhantomRuntime).toBe(true);
     });
 
     it('#off() can disable an event whose listener is going to run locally', function*() {
@@ -450,16 +449,16 @@ describe('Page', () => {
         let page = yield phantom.createPage();
 
         yield page.on('onResourceReceived', true, function () {
-            this.runnedInPhantomRuntime = true;
+            runnedInPhantomRuntime = true;
         });
 
         yield page.off('onResourceReceived');
 
         yield page.open('http://localhost:8888/test');
 
-        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+        let runnedInPhantomRuntime = yield phantom.windowProperty('runnedInPhantomRuntime');
 
-        expect(runnedOnPhantomRuntime).toBeFalsy();
+        expect(runnedInPhantomRuntime).toBeFalsy();
 
     });
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -123,7 +123,7 @@ describe('Page', () => {
         });
         expect(response).toEqual('test');
     });
-    
+
     it('#evaluateJavaScript(\'function(){return document.title}\') executes correctly', function*() {
         let page = yield phantom.createPage();
         yield page.open('http://localhost:8888/test.html');
@@ -303,6 +303,164 @@ describe('Page', () => {
         });
 
         expect(response).toBe(true);
+    });
+
+    it('#on() can register an event in the page and run the code locally', function* () {
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onResourceReceived', function () {
+            runnedHere = true;
+        });
+
+        yield page.open('http://localhost:8888/test');
+
+        expect(runnedHere).toBe(true);
+    });
+
+    it('#on() event registered does not run if not triggered', function* () {
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onResourceReceived', function () {
+            runnedHere = true;
+        });
+
+        expect(runnedHere).toBe(false);
+    });
+
+    it('#on() can register more than one event of the same type', function* () {
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onResourceReceived', function () {
+            runnedHere = true;
+        });
+
+        let runnedHereToo = false;
+
+        yield page.on('onResourceReceived', function () {
+            runnedHereToo = true;
+        });
+
+        yield page.open('http://localhost:8888/test');
+
+        expect(runnedHere).toBe(true);
+        expect(runnedHereToo).toBe(true);
+    });
+
+
+    it('#on() can pass parameters', function* () {
+        let page = yield phantom.createPage();
+        let parameterProvided = false;
+
+        yield page.on('onResourceReceived', function (status, param) {
+            parameterProvided = param;
+        }, 'param');
+
+        yield page.open('http://localhost:8888/test');
+
+        expect(parameterProvided).toBe('param');
+    });
+
+
+    it('#on() can register an event in the page which code runs in phantom runtime', function* () {
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onLoadFinished', true, function () {
+            runnedHere = true;
+            this.runnedInPhantomRuntime = true;
+        });
+
+        yield page.open('http://localhost:8888/test');
+
+        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+
+        expect(runnedHere).toBe(false);
+        expect(runnedOnPhantomRuntime).toBe(true);
+    });
+
+    it('#on() can pass parameters to functions to be executed in phantom runtime', function* () {
+        //failing
+        let page = yield phantom.createPage();
+
+        yield page.on('onResourceReceived', true, function (status, param) {
+            this.parameterProvided = param;
+        }, 'param');
+
+        yield page.open('http://localhost:8888/test');
+
+        let parameterProvided = yield page.property('parameterProvided');
+
+        expect(parameterProvided).toBe('param');
+    });
+
+    it('#on() event supposed to run in phantom runtime wont run if not triggered', function* () {
+        let page = yield phantom.createPage();
+
+        yield page.on('onResourceReceived', true, function () {
+            this.runnedInPhantomRuntime = true;
+        });
+
+        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+
+        expect(runnedOnPhantomRuntime).toBeFalsy();
+    });
+
+    it('#on() can register at the same event to run locally or in phantom runtime', function* () {
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onResourceReceived', true, function () {
+            this.runnedInPhantomRuntime = true;
+        });
+
+        yield page.on('onResourceReceived', function () {
+            runnedHere = true;
+        });
+
+        yield page.open('http://localhost:8888/test');
+
+        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+
+        expect(runnedHere).toBe(true);
+        expect(runnedOnPhantomRuntime).toBe(true);
+    });
+
+    it('#off() can disable an event whose listener is going to run locally', function*() {
+
+        let page = yield phantom.createPage();
+        let runnedHere = false;
+
+        yield page.on('onResourceReceived', function () {
+            runnedHere = true;
+        });
+
+        yield page.off('onResourceReceived');
+
+        yield page.open('http://localhost:8888/test');
+
+        expect(runnedHere).toBe(false);
+
+    });
+
+    it('#off() can disable an event whose listener is going to run on the phantom process', function*() {
+
+        let page = yield phantom.createPage();
+
+        yield page.on('onResourceReceived', true, function () {
+            this.runnedInPhantomRuntime = true;
+        });
+
+        yield page.off('onResourceReceived');
+
+        yield page.open('http://localhost:8888/test');
+
+        let runnedOnPhantomRuntime = yield page.property('runnedInPhantomRuntime');
+
+        expect(runnedOnPhantomRuntime).toBeFalsy();
+
     });
 
 });


### PR DESCRIPTION
### Proposed changes in this pull request

I added a mechanism to add event listeners to a phantom page. These event listeners would run in node runtime by default (and would support closures and all Js functions goodness). 

I added the `#on(event, runOnPhantom, callback, args**)` method to the `Page` class, as well as the `#off(event)` method. The off method remove all events listeners. 

Also I added the on method to the Phantom class the methods `#on()` and `#off()`, but it will set the events to a specified target (by its id).

If you use `property` to set an event, then it would override all the events set using `#on()`. If you use `#on()` again, it would restore all the event listeners set by `#on()`, and the one set with property would be overwritten. 

It works the same as property, for the functions when you specify you want the event to run on phantom runtime. Even the `OutObject`'s works as well.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review
