### PR TITLE
Add support for page#switchToFrame and page#switchToMainFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ page.evaluateJavaScript('function() { return document.getElementById(\'foo\').in
 });
 ```
 
+### `page#switchToFrame`
+
+Switch to the frame specified by a frame name or a frame position:
+
+```js
+page.switchToFrame(framePositionOrName).then(function() {
+    // do work
+});
+```
+
+### `page#switchToMainFrame`
+
+Switch to the main frame of the page:
+
+```js
+page.switchToMainFrame().then(function() {
+    // do work
+});
+```
+
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Switch to the frame specified by a frame name or a frame position:
 
 ```js
 page.switchToFrame(framePositionOrName).then(function() {
-    // do work
+    // now the context of `page` will be the iframe if frame name or position exists
 });
 ```
 
@@ -184,7 +184,7 @@ Switch to the main frame of the page:
 
 ```js
 page.switchToMainFrame().then(function() {
-    // do work
+    // now the context of `page` will the main frame
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "babel-core": "^6.7.7",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "del": "^2.2.0",

--- a/src/page.js
+++ b/src/page.js
@@ -11,7 +11,8 @@ export default class Page {
 
 const methods = [
     'open', 'render', 'close', 'property', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
-    'evaluate', 'evaluateJavaScript', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent'
+    'evaluate', 'evaluateJavaScript', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent',
+    'switchToMainFrame', 'switchToFrame'
 ];
 
 methods.forEach(method => {

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -464,7 +464,7 @@ describe('Page', () => {
      * For testing iframes we need to be sure the iframe is loaded before validating.
      * This function checks that an iframe with id 'testframe' has been loaded.
      * There are 2 exit conditions, when the frame is loaded or 
-     * a timeout of 20 intervals of 100ms is reached.
+     * a timeout of 50 intervals of 100ms is reached.
      * This function is required for stability of the next two tests,
      * #switchToFrame(framePosition) and #switchToMainFrame().
      */
@@ -480,7 +480,7 @@ describe('Page', () => {
             var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
             // Check if loading is complete
-            if (checkCount > 20 || iframeDoc.readyState  === 'complete') {
+            if (checkCount > 50 || iframeDoc.readyState  === 'complete') {
                 return;
             } 
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -360,6 +360,7 @@ describe('Page', () => {
 
         yield page.setContent(html, 'http://localhost:8888/');
         yield page.evaluate(checkframe);
+        // need to switch to child frame here to test switchToMainFrame() works
         yield page.switchToFrame(0);
         yield page.switchToMainFrame();
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -306,8 +306,10 @@ describe('Page', () => {
     });
 
     /**
-     * Check that an iframe with id 'testframe' has been loaded.
-     * Returns after iframe is loaded or after 10 intervals of 100ms.
+     * For testing iframes we need to be sure the iframe is loaded before validating.
+     * This function checks that an iframe with id 'testframe' has been loaded.
+     * There are 2 exit conditions, when the frame is loaded or 
+     * a timeout of 10 intervals of 100ms is reached.
      * This function is required for stability of the next two tests,
      * #switchToFrame(framePosition) and #switchToMainFrame().
      *
@@ -317,12 +319,10 @@ describe('Page', () => {
 
         /**
          * Need to define the function since we will be re-using it.
-         *
          */
         function checkIframeLoaded() {
             // Get a handle to the iframe element
             var iframe = document.getElementById('testframe');
-
             var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
             // Check if loading is complete
@@ -331,7 +331,6 @@ describe('Page', () => {
             } 
 
             checkCount += 1;
-
             // if we are here, it is not loaded. Set things up so we check the status again in 100 milliseconds
             window.setTimeout(checkIframeLoaded, 100);
         }
@@ -344,9 +343,7 @@ describe('Page', () => {
         let html = '<html><head><title>Iframe Test</title></head><body><iframe id="testframe" src="http://localhost:8888/test.html"></iframe></body></html>';
 
         yield page.setContent(html, 'http://localhost:8888/');
-
         yield page.evaluate(checkframe);
-
         yield page.switchToFrame(0);
 
         let responseIframe = yield page.evaluate(function () {
@@ -363,9 +360,7 @@ describe('Page', () => {
 
         yield page.setContent(html, 'http://localhost:8888/');
         yield page.evaluate(checkframe);
-
         yield page.switchToFrame(0);
-
         yield page.switchToMainFrame();
 
         let responseMainFrame = yield page.evaluate(function () {

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -464,10 +464,9 @@ describe('Page', () => {
      * For testing iframes we need to be sure the iframe is loaded before validating.
      * This function checks that an iframe with id 'testframe' has been loaded.
      * There are 2 exit conditions, when the frame is loaded or 
-     * a timeout of 10 intervals of 100ms is reached.
+     * a timeout of 20 intervals of 100ms is reached.
      * This function is required for stability of the next two tests,
      * #switchToFrame(framePosition) and #switchToMainFrame().
-     *
      */
     function checkframe() {
         var checkCount = 0;
@@ -481,7 +480,7 @@ describe('Page', () => {
             var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
             // Check if loading is complete
-            if (checkCount > 10 || iframeDoc.readyState  === 'complete') {
+            if (checkCount > 20 || iframeDoc.readyState  === 'complete') {
                 return;
             } 
 


### PR DESCRIPTION
### Proposed changes in this pull request
Support for [page#switchToFrame](http://phantomjs.org/api/webpage/method/switch-to-frame.html) and [page#switchToMainFrame](http://phantomjs.org/api/webpage/method/switch-to-main-frame.html).

### Notes
I had to include `babel-core `in dev-dependencies of the package.json because my tests would not run without it. We can remove it from the PR if necessary.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated

@amir20 to review