### PR TITLE
Clean up logging

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -210,6 +210,7 @@ export default class Phantom {
     exit() {
         clearInterval(this.heartBeatId);
         this.execute('phantom', 'exit');
+        this.process.kill('SIGHUP');
     }
 
     _heartBeat() {

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -95,12 +95,16 @@ export default class Phantom {
      */
     createPage() {
         return this.execute('phantom', 'createPage').then(response => {
-            return new Proxy(new Page(this, response.pageId), {
-                set: function (target, prop) {
-                    logger.warn(`Using page.${prop} = ...; is not supported. Use page.property('${prop}', ...) instead. See the README file for more examples of page#property.`);
-                    return false;
-                }
-            });
+            let page = new Page(this, response.pageId);
+            if (typeof Proxy === 'function') {
+                page = new Proxy(page, {
+                    set: function (target, prop) {
+                        logger.warn(`Using page.${prop} = ...; is not supported. Use page.property('${prop}', ...) instead. See the README file for more examples of page#property.`);
+                        return false;
+                    }
+                });
+            }
+            return page;
         });
     }
 

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -94,9 +94,15 @@ export default class Phantom {
      * @returns {Promise.<Page>}
      */
     createPage() {
-        return this.execute('phantom', 'createPage').then(response => new Page(this, response.pageId));
+        return this.execute('phantom', 'createPage').then(response => {
+            return new Proxy(new Page(this, response.pageId), {
+                set: function (target, prop) {
+                    logger.warn(`Using page.${prop} = ...; is not supported. Use page.property('${prop}', ...) instead. See the README file for more examples of page#property.`);
+                    return false;
+                }
+            });
+        });
     }
-
 
     /**
      * Creates a special object that can be used for returning data back from PhantomJS

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -94,7 +94,14 @@ export default class Phantom {
      * @returns {Promise.<Page>}
      */
     createPage() {
-        return this.execute('phantom', 'createPage').then(response => new Page(this, response.pageId));
+        return this.execute('phantom', 'createPage').then(response => {
+            return new Proxy(new Page(this, response.pageId), {
+                set: function (target, prop) {
+                    logger.warn(`Using page.${prop} = ...; is not supported. Use page.property('${prop}', ...) instead. See the README file for more examples of page#property.`);
+                    return false;
+                }
+            });
+        });
     }
 
     /**

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -216,7 +216,6 @@ export default class Phantom {
     exit() {
         clearInterval(this.heartBeatId);
         this.execute('phantom', 'exit');
-        this.process.kill('SIGHUP');
     }
 
     _heartBeat() {

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -7,7 +7,7 @@ import Linerstream from "linerstream";
 import Page from "./page";
 import Command from "./command";
 import OutObject from "./out_object";
-import EventEmitter from 'events';
+import EventEmitter from "events";
 
 const logger = new winston.Logger({
     transports: [

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -94,14 +94,7 @@ export default class Phantom {
      * @returns {Promise.<Page>}
      */
     createPage() {
-        return this.execute('phantom', 'createPage').then(response => {
-            return new Proxy(new Page(this, response.pageId), {
-                set: function (target, prop) {
-                    logger.warn(`Using page.${prop} = ...; is not supported. Use page.property('${prop}', ...) instead. See the README file for more examples of page#property.`);
-                    return false;
-                }
-            });
-        });
+        return this.execute('phantom', 'createPage').then(response => new Page(this, response.pageId));
     }
 
     /**

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -305,7 +305,7 @@ describe('Page', () => {
         expect(response).toBe(true);
     });
 
-    it('#on() can register an event in the page and run the code locally', function* () {
+    it('#on() can register an event in the page and run the code locally', function*() {
         let page = yield phantom.createPage();
         let runnedHere = false;
 
@@ -318,7 +318,7 @@ describe('Page', () => {
         expect(runnedHere).toBe(true);
     });
 
-    it('#on() event registered does not run if not triggered', function* () {
+    it('#on() event registered does not run if not triggered', function*() {
         let page = yield phantom.createPage();
         let runnedHere = false;
 
@@ -329,7 +329,7 @@ describe('Page', () => {
         expect(runnedHere).toBe(false);
     });
 
-    it('#on() can register more than one event of the same type', function* () {
+    it('#on() can register more than one event of the same type', function*() {
         let page = yield phantom.createPage();
         let runnedHere = false;
 
@@ -350,7 +350,7 @@ describe('Page', () => {
     });
 
 
-    it('#on() can pass parameters', function* () {
+    it('#on() can pass parameters', function*() {
         let page = yield phantom.createPage();
         let parameterProvided = false;
 
@@ -364,7 +364,7 @@ describe('Page', () => {
     });
 
 
-    it('#on() can register an event in the page which code runs in phantom runtime', function* () {
+    it('#on() can register an event in the page which code runs in phantom runtime', function*() {
         let page = yield phantom.createPage();
         let runnedHere = false;
 
@@ -381,7 +381,7 @@ describe('Page', () => {
         expect(runnedInPhantomRuntime).toBe(true);
     });
 
-    it('#on() can pass parameters to functions to be executed in phantom runtime', function* () {
+    it('#on() can pass parameters to functions to be executed in phantom runtime', function*() {
         let page = yield phantom.createPage();
 
         yield page.on('onResourceReceived', true, function (status, param) {
@@ -395,7 +395,7 @@ describe('Page', () => {
         expect(parameterProvided).toBe('param');
     });
 
-    it('#on() event supposed to run in phantom runtime wont run if not triggered', function* () {
+    it('#on() event supposed to run in phantom runtime wont run if not triggered', function*() {
         let page = yield phantom.createPage();
 
         yield page.on('onResourceReceived', true, function () {
@@ -407,7 +407,7 @@ describe('Page', () => {
         expect(runnedInPhantomRuntime).toBeFalsy();
     });
 
-    it('#on() can register at the same event to run locally or in phantom runtime', function* () {
+    it('#on() can register at the same event to run locally or in phantom runtime', function*() {
         let page = yield phantom.createPage();
         let runnedHere = false;
 
@@ -489,7 +489,7 @@ describe('Page', () => {
             // are we in the main frame?
             return !window.frameElement;
         });
-        
+
         // confirm we are in the main frame
         expect(inMainFrame).toBe(true);
     });


### PR DESCRIPTION
### Proposed changes in this pull request

This pull requests does a few things: 
- Cleans up logging so that what using `page.property = ...` throws a warning. 
- Cleans up spaces 
- ~~Force kill phantomjs process~~ Looks like this breaks travis. 

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review
