### PR TITLE
Add support for page#reload

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -49,7 +49,7 @@ export default class Page {
 const methods = [
     'open', 'render', 'close', 'property', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
     'evaluate', 'evaluateJavaScript', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent',
-    'switchToMainFrame', 'switchToFrame'
+    'switchToMainFrame', 'switchToFrame', 'reload'
 ];
 
 methods.forEach(method => {

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -493,6 +493,21 @@ describe('Page', () => {
         // confirm we are in the main frame
         expect(inMainFrame).toBe(true);
     });
+    
+    it('#reload() will reload the current page', function*() {
+        let page = yield phantom.createPage();
+        let reloaded = false;
+        
+        yield page.open('http://localhost:8888/test');
+        yield page.on('onNavigationRequested', function(url, type) {
+            if (type === 'Reload') {
+                reloaded = true;
+            }
+        });
+        yield page.reload();
+        
+        expect(reloaded).toBe(true);
+    });
 
 });
 


### PR DESCRIPTION
### Proposed changes in this pull request

The commit adds support for [page#reload()](http://phantomjs.org/api/webpage/method/reload.html). As of right now you need to evaluate the function 'location.reload()' in the context of the web page to perform a reload.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

