### PR TITLE
Add ability to define and invoke methods (#487)

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -43,6 +43,13 @@ export default class Page {
     off(event) {
         return this.phantom.off(event, this.target);
     }
+    
+    /**
+     * Invokes an asynchronous method
+     */
+    invokeAsyncMethod() {
+        return this.phantom.execute(this.target, 'invokeAsyncMethod', [].slice.call(arguments));
+    }
 }
 
 

--- a/src/page.js
+++ b/src/page.js
@@ -57,6 +57,13 @@ export default class Page {
     invokeMethod() {
         return this.phantom.execute(this.target, 'invokeMethod', [].slice.call(arguments));
     }
+    
+    /**
+     * Defines a method
+     */
+    defineMethod(name, implementation) {
+        return this.phantom.execute(this.target, 'defineMethod', [name, implementation]);
+    }
 }
 
 

--- a/src/page.js
+++ b/src/page.js
@@ -64,12 +64,26 @@ export default class Page {
     defineMethod(name, implementation) {
         return this.phantom.execute(this.target, 'defineMethod', [name, implementation]);
     }
+    
+    /**
+     * Gets or sets a property
+     */
+    property() {
+        return this.phantom.execute(this.target, 'property', [].slice.call(arguments));
+    }
+    
+    /**
+     * Gets or sets a setting
+     */
+    setting() {
+        return this.phantom.execute(this.target, 'setting', [].slice.call(arguments));
+    }
 }
 
 
 const methods = [
-    'open', 'render', 'close', 'property', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
-    'evaluate', 'evaluateJavaScript', 'setting', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent',
+    'open', 'render', 'close', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
+    'evaluate', 'evaluateJavaScript', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent',
     'switchToMainFrame', 'switchToFrame', 'reload'
 ];
 

--- a/src/page.js
+++ b/src/page.js
@@ -112,6 +112,6 @@ asyncMethods.forEach(method => {
 
 methods.forEach(method => {
     Page.prototype[method] = function () {
-        return this.phantom.execute(this.target, method, [].slice.call(arguments));
+        return this.invokeMethod.apply(this, [method].concat([].slice.call(arguments)));
     }
 });

--- a/src/page.js
+++ b/src/page.js
@@ -80,12 +80,35 @@ export default class Page {
     }
 }
 
+const asyncMethods = [
+    'includeJs',
+    'open'
+];
 
 const methods = [
-    'open', 'render', 'close', 'injectJs', 'includeJs', 'openUrl', 'stop', 'renderBase64',
-    'evaluate', 'evaluateJavaScript', 'addCookie', 'deleteCookie', 'clearCookies', 'setContent', 'sendEvent',
-    'switchToMainFrame', 'switchToFrame', 'reload'
+    'addCookie',
+    'clearCookies',
+    'close',
+    'deleteCookie',
+    'evaluate',
+    'evaluateJavaScript',
+    'injectJs', 
+    'openUrl',
+    'reload',
+    'render',
+    'renderBase64',
+    'sendEvent',
+    'setContent',
+    'stop',
+    'switchToFrame',
+    'switchToMainFrame'
 ];
+
+asyncMethods.forEach(method => {
+    Page.prototype[method] = function () {
+        return this.invokeAsyncMethod.apply(this, [method].concat([].slice.call(arguments)));
+    }; 
+});
 
 methods.forEach(method => {
     Page.prototype[method] = function () {

--- a/src/page.js
+++ b/src/page.js
@@ -50,6 +50,13 @@ export default class Page {
     invokeAsyncMethod() {
         return this.phantom.execute(this.target, 'invokeAsyncMethod', [].slice.call(arguments));
     }
+    
+    /**
+     * Invokes a method
+     */
+    invokeMethod() {
+        return this.phantom.execute(this.target, 'invokeMethod', [].slice.call(arguments));
+    }
 }
 
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -105,6 +105,13 @@ const commands = {
             command.response = result;
             completeCommand(command);
         }));
+    },
+    
+    invokeMethod: function (command) {
+        let target = objectSpace[command.target];
+        let method = target[command.params[0]];
+        command.response = method.apply(target, command.params.slice(1));
+        completeCommand(command);
     }
 };
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -11,12 +11,6 @@ const objectSpace = {
 const events = {};
 
 /**
- * All methods that have a callback in their signature
- * @type {string[]}
- */
-const haveCallbacks = ['open', 'includeJs'];
-
-/**
  * All commands that have a custom implementation
  */
 const commands = {
@@ -191,18 +185,8 @@ function executeCommand(command) {
     } else if (objectSpace[command.target]) {
         const target = objectSpace[command.target];
         const method = target[command.name];
-
-        if (haveCallbacks.indexOf(command.name) === -1) {
-            command.response = method.apply(target, command.params);
-            completeCommand(command);
-        } else {
-            let params = command.params.slice(); // copy params
-            params.push(status => {
-                command.response = status;
-                completeCommand(command);
-            });
-            method.apply(target, params);
-        }
+        command.response = method.apply(target, command.params);
+        completeCommand(command);
     } else {
         throw new Error(`Cannot find ${command.name} method to execute on ${command.target} object.`);
     }

--- a/src/shim.js
+++ b/src/shim.js
@@ -97,7 +97,15 @@ const commands = {
         completeCommand(command);
     },
 
-    noop: command => completeCommand(command)
+    noop: command => completeCommand(command),
+    
+    invokeAsyncMethod: function (command) {
+        let target = objectSpace[command.target];
+        target[command.params[0]].apply(target, command.params.slice(1).concat(result => {
+            command.response = result;
+            completeCommand(command);
+        }));
+    }
 };
 
 /**

--- a/src/shim.js
+++ b/src/shim.js
@@ -112,6 +112,12 @@ const commands = {
         let method = target[command.params[0]];
         command.response = method.apply(target, command.params.slice(1));
         completeCommand(command);
+    },
+    
+    defineMethod: function (command) {
+        let target = objectSpace[command.target];
+        target[command.params[0]] = command.params[1];
+        completeCommand(command);
     }
 };
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -508,6 +508,22 @@ describe('Page', () => {
         
         expect(reloaded).toBe(true);
     });
+    
+    it('#invokeAsyncMethod(\'includeJs\', \'http://localhost:8888/script.js\') executes correctly', function*() {
+        let page = yield phantom.createPage();
+        yield page.open('http://localhost:8888/test');
+        yield page.invokeAsyncMethod('includeJs', 'http://localhost:8888/script.js');
+        let response = yield page.evaluate(function () {
+            return fooBar; // eslint-disable-line no-undef
+        });
+        expect(response).toEqual(2);
+    });
+    
+    it('#invokeAsyncMethod(\'open\', \'http://localhost:8888/test\') executes correctly', function*() {
+        let page = yield phantom.createPage();
+        let status = yield page.invokeAsyncMethod('open', 'http://localhost:8888/test');
+        expect(status).toEqual('success');
+    });
 
 });
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -524,6 +524,20 @@ describe('Page', () => {
         let status = yield page.invokeAsyncMethod('open', 'http://localhost:8888/test');
         expect(status).toEqual('success');
     });
+    
+    it('#invokeMethod(\'evaluate\', \'function () { return document.title }\') executes correctly', function*() {
+        let page = yield phantom.createPage();
+        yield page.open('http://localhost:8888/test.html');
+        let response = yield page.invokeMethod('evaluate', 'function () { return document.title }');
+        expect(response).toEqual('Page Title'); 
+    });
+    
+    it('#invokeMethod(\'renderBase64\') executes correctly', function*() {
+        let page = yield phantom.createPage();
+        yield page.open('http://localhost:8888/test');
+        let content = yield page.invokeMethod('renderBase64', 'PNG');
+        expect(content).not.toBeNull();
+    });
 
 });
 

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -538,6 +538,15 @@ describe('Page', () => {
         let content = yield page.invokeMethod('renderBase64', 'PNG');
         expect(content).not.toBeNull();
     });
+    
+    it('#defineMethod(name, implementation) defines a method', function*() {
+        let page = yield phantom.createPage();
+        yield page.defineMethod('getZoomFactor', function() {
+            return this.zoomFactor; // eslint-disable-line no-invalid-this
+        });
+        let zoomFactor = yield page.invokeMethod('getZoomFactor');
+        expect(zoomFactor).toEqual(1);
+    });
 
 });
 


### PR DESCRIPTION
This pull request addresses issue https://github.com/amir20/phantomjs-node/issues/487, and it:

- adds `page.invokeAsyncMethod`, which invokes any asynchronous method ('includeJs', 'open', etc.)

- adds `page.invokeMethod`, which invokes any method

- adds `page.defineMethod`, which defines a method

- reimplements `property`, `setting` as commands rather than methods 

- binds the built-in/native methods to `invokeAsyncMethod`, and `invokeMethod`

- removes some deprecated code

Examples:

```js
'use strict';

const phantomjs = require('phantom');

let page;
let phantom;

phantomjs.create().then(function (instance) {
    phantom = instance;
    return phantom.createPage();
}).then(function (instance) {
    page = instance;
    return page.defineMethod('exists', function (selector, callback) {
        var element = this.evaluate(function (selector) {
            return document.querySelector(selector);
        }, selector);
        callback(element !== null);
    });
}).then(function (instance) {
    return page.open('http://google.com/');
}).then(function (status) {
    return page.invokeAsyncMethod('exists', 'input[type="submit"]');
}).then(function (exists) {
    console.log(exists);
    phantom.exit();
});
```

```js
'use strict';

const phantomjs = require('phantom');

let page;
let phantom;

phantomjs.create().then(function (instance) {
    phantom = instance;
    return phantom.createPage();
}).then(function (instance) {
    page = instance;
    return page.defineMethod('exists', function (selector) {
        var element = this.evaluate(function (selector) {
            return document.querySelector(selector);
        }, selector);
        return element !== null;
    });
}).then(function (instance) {
    return page.open('http://google.com/');
}).then(function (status) {
    return page.invokeMethod('exists', 'input[type="submit"]');
}).then(function (exists) {
    console.log(exists);
    phantom.exit();
});
```

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

Hopefully I didn't mess anything up...