### PR TITLE
All methods are explicitly invoked via invokeAsyncMethod or invokeMethod.

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -61,8 +61,8 @@ export default class Page {
     /**
      * Defines a method
      */
-    defineMethod(name, implementation) {
-        return this.phantom.execute(this.target, 'defineMethod', [name, implementation]);
+    defineMethod(name, definition) {
+        return this.phantom.execute(this.target, 'defineMethod', [name, definition]);
     }
     
     /**

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -219,7 +219,7 @@ export default class Phantom {
      */
     exit() {
         clearInterval(this.heartBeatId);
-        this.execute('phantom', 'exit');
+        this.execute('phantom', 'invokeMethod', ['exit']);
     }
 
     _heartBeat() {

--- a/src/shim.js
+++ b/src/shim.js
@@ -176,20 +176,14 @@ function syncOutObjects(objects) {
 }
 
 /**
- * Executes a command by first checking if it is a custom method and then calling the method on the target.
+ * Executes a command.
  * @param command the command to execute
  */
 function executeCommand(command) {
     if (commands[command.name]) {
         return commands[command.name](command);
-    } else if (objectSpace[command.target]) {
-        const target = objectSpace[command.target];
-        const method = target[command.name];
-        command.response = method.apply(target, command.params);
-        completeCommand(command);
-    } else {
-        throw new Error(`Cannot find ${command.name} method to execute on ${command.target} object.`);
     }
+    throw new Error(`'${command.name}' isn't a command.`);
 }
 
 /**

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -539,7 +539,7 @@ describe('Page', () => {
         expect(content).not.toBeNull();
     });
     
-    it('#defineMethod(name, implementation) defines a method', function*() {
+    it('#defineMethod(name, definition) defines a method', function*() {
         let page = yield phantom.createPage();
         yield page.defineMethod('getZoomFactor', function() {
             return this.zoomFactor; // eslint-disable-line no-invalid-this

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -248,9 +248,9 @@ describe('Page', () => {
 
     it('#reject(...) works when there is an error', function*() {
         try {
-            yield phantom.execute('phantom', 'doesNotExist');
+            yield phantom.execute('page', 'nonexistentCommand');
         } catch (e) {
-            expect(e.message).toEqual("undefined is not an object (evaluating 'method.apply')");
+            expect(e.message).toEqual("'nonexistentCommand' isn't a command.");
         }
     });
 


### PR DESCRIPTION
This pull request binds `phantom.exit` to `invokeMethod`, which means that all methods are now explicitly invoked via `invokeAsyncMethod` or `invokeMethod`, and that the block of code that implicitly invoked methods can be removed. It also updates the obsolete 'Page#reject' test.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review
