### PR TITLE
Remove redundant lines

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -77,7 +77,6 @@ export default class Phantom {
             logger.error(`Could not spawn [${phantomjs.path}] executable. Please make sure phantomjs is installed correctly.`);
             logger.error(error);
             this.kill(`Process got an error: ${error}`);
-            process.exit(1);
         });
 
         this.process.stdin.on('error', (e) => {
@@ -161,7 +160,6 @@ export default class Phantom {
             return r;
         });
         logger.debug('Sending: %s', json);
-
 
         this.process.stdin.write(json + os.EOL, 'utf8');
         return promise;


### PR DESCRIPTION
Simply removes the redundant `process.exit(1);` line.

#### Checklist
* [ ] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review
