### PR TITLE
Add test for Page#openUrl

### DIFF
--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -547,6 +547,16 @@ describe('Page', () => {
         let zoomFactor = yield page.invokeMethod('getZoomFactor');
         expect(zoomFactor).toEqual(1);
     });
-
+    
+    it('#openUrl() opens a URL', function(done) {
+        phantom.createPage().then(function(page) {
+            page.on('onLoadFinished', false, function(status) {
+                expect(status).toEqual('success');
+                done();
+            });
+            return page.openUrl('http://localhost:8888/test', 'GET', {});
+        });
+    });
+    
 });
 


### PR DESCRIPTION
I noticed that there isn't a test for `Page#openUrl`, so I added one.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

