### PR TITLE
Add Page#setProxy

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -99,6 +99,7 @@ const methods = [
     'renderBase64',
     'sendEvent',
     'setContent',
+    'setProxy',
     'stop',
     'switchToFrame',
     'switchToMainFrame'

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -558,5 +558,13 @@ describe('Page', () => {
         });
     });
     
+    it('#setProxy() sets the proxy', function*() {
+        let page = yield phantom.createPage();
+        yield page.setProxy('http://localhost:8888');
+        yield page.open('http://phantomjs.org/');
+        let text = yield page.property('plainText');
+        expect(text).toEqual('hi, http://phantomjs.org/');
+    });
+    
 });
 


### PR DESCRIPTION
I added `Page#setProxy`, on behalf of @wesleymilan.

The test uses the server as a proxy, so http://phantomjs.org/ won't actually be opened/requested, as the server immediately responds 'hi, http://phantomjs.org/' instead.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

