### PR TITLE
Add custom PhantomJS path support by passing it in config object to phantom.create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,23 @@ $ npm install phantom --save
 
 ## `phantom` object API
 
-To create a new instance of `phantom` use `phantom.create()` to return a `Promise` which should resolve to a `phantom` object. If you want add parameters to the phantomjs process you can do so by doing:
+### `phantom#create`
+
+To create a new instance of `phantom` use `phantom.create()` which returns a `Promise` which should resolve with a `phantom` object.
+If you want add parameters to the phantomjs process you can do so by doing:
 
 ```js
 var phantom = require('phantom');
 phantom.create(['--ignore-ssl-errors=yes', '--load-images=no']).then(...)
 ```
+You can also explicitly set phantomjs path to use by passing it in cofig object:
+```js
+var phantom = require('phantom');
+phantom.create([], {phantomPath: '/path/to/phantomjs'}).then(...)
+```
+
+### `phantom#createPage`
+
 To create a new `page`, you have to call `createPage()`:
 
 ```js
@@ -78,7 +89,19 @@ phantom.create().then(function(ph) {
 });
 ```
 
-Make sure to call `#exit()` on the phantom instance to kill the phantomjs process. Otherwise, the process will never exit.
+### `phantom#exit`
+
+Sends an exit call to phantomjs process and returns a `Promise`.
+
+Make sure to call it on the phantom instance to kill the phantomjs process. Otherwise, the process will never exit.
+
+### `phantom#kill`
+
+Kills the underlying phantomjs process (by sending `SIGKILL` to it).
+
+It may be a good idea to register handlers to `SIGTERM` and `SIGINT` signals with `#kill()`.
+
+However, be aware that phantomjs process will get detached (and thus won't exit) if node process that spawned it receives `SIGKILL`!
 
 ## `page` object API
 
@@ -108,7 +131,7 @@ page.property('plainText').then(function(content) {
   Page properties can be set using the `#property(key, value)` method.
 
   ```js
-page.property('viewportSize', {width: 800, height: 600}).then(function() {  
+page.property('viewportSize', {width: 800, height: 600}).then(function() {
 });
   ```
 When setting values, using `then()` is optional. But beware that the next method to phantom will block until it is ready to accept a new message.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ phantom.create().then(function(ph) {
 
 ### `phantom#exit`
 
-Sends an exit call to phantomjs process and returns a `Promise`.
+Sends an exit call to phantomjs process.
 
 Make sure to call it on the phantom instance to kill the phantomjs process. Otherwise, the process will never exit.
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,5 @@ import Phantom from "./phantom";
  * @param args
  * @returns {Promise}
  */
-module.exports.create = args => new Promise(resolve => resolve(new Phantom(args)));
+module.exports.create = (args, config) => new Promise(resolve => resolve(new Phantom(args, config)));
 

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -27,20 +27,18 @@ export default class Phantom {
      * Creates a new instance of Phantom
      *
      * @param args command args to pass to phantom process
+     * @param [config] configuration object
+     * @param [config.phantomPath] path to phantomjs executable
      */
-    constructor(args = []) {
+    constructor(args = [], config = {}) {
         if (!Array.isArray(args)) {
             throw new Error('Unexpected type of parameters. Expecting args to be array.');
         }
-
-        let phantomPath = phantomjs.path;
-        for (let i = 0; i < args.length; i += 1) {
-            if(args[i].indexOf('phantomPath=') === 0) {
-                phantomPath = args[i].slice(12);
-                args.splice(i, 1);
-                break;
-            }
+        if (!config || typeof(config) !== 'object') {
+            throw new Error('Unexpected type of parameters. Expecting config to be object.');
         }
+
+        let phantomPath = typeof(config.phantomPath) === 'string' ? config.phantomPath : phantomjs.path;
 
         let pathToShim = path.normalize(__dirname + '/shim.js');
         logger.debug(`Starting ${phantomPath} ${args.concat([pathToShim]).join(' ')}`);

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -233,11 +233,10 @@ export default class Phantom {
 
     /**
      * Cleans up and end the phantom process
-     * @returns {Promise}
      */
     exit() {
         clearInterval(this.heartBeatId);
-        return this.execute('phantom', 'invokeMethod', ['exit']);
+        this.execute('phantom', 'invokeMethod', ['exit']);
     }
 
     /**

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -233,10 +233,11 @@ export default class Phantom {
 
     /**
      * Cleans up and end the phantom process
+     * @returns {Promise}
      */
     exit() {
         clearInterval(this.heartBeatId);
-        this.execute('phantom', 'invokeMethod', ['exit']);
+        return this.execute('phantom', 'invokeMethod', ['exit']);
     }
 
     /**

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -34,11 +34,11 @@ export default class Phantom {
         if (!Array.isArray(args)) {
             throw new Error('Unexpected type of parameters. Expecting args to be array.');
         }
-        if (!config || typeof(config) !== 'object') {
+        if (!config || typeof config !== 'object') {
             throw new Error('Unexpected type of parameters. Expecting config to be object.');
         }
 
-        let phantomPath = typeof(config.phantomPath) === 'string' ? config.phantomPath : phantomjs.path;
+        let phantomPath = typeof config.phantomPath === 'string' ? config.phantomPath : phantomjs.path;
 
         let pathToShim = path.normalize(__dirname + '/shim.js');
         logger.debug(`Starting ${phantomPath} ${args.concat([pathToShim]).join(' ')}`);

--- a/src/spec/phantom_spec.js
+++ b/src/spec/phantom_spec.js
@@ -22,7 +22,7 @@ describe('Phantom', () => {
         });
     });
 
-    it('#create([]) execute with no parameters', () => {
+    it('#create([], {}) execute with no parameters', () => {
         spyOn(child_process, 'spawn').and.callThrough();
         let ProxyPhantom = proxyquire('../phantom', {
             child_process: child_process
@@ -45,12 +45,28 @@ describe('Phantom', () => {
         pp.exit();
     });
 
+    it('#create([], {phantomPath: \'phantomjs\'}) execute phantomjs from custom path with no parameters', () => {
+        spyOn(child_process, 'spawn').and.callThrough();
+        let ProxyPhantom = proxyquire('../phantom', {
+            child_process: child_process
+        }).default;
+
+        let pp = new ProxyPhantom([], {phantomPath: 'phantomjs'});
+        let pathToShim = path.normalize(__dirname + '/../shim.js');
+        expect(child_process.spawn).toHaveBeenCalledWith('phantomjs', [pathToShim]);
+        pp.exit();
+    });
+
     it('#create("--ignore-ssl-errors=yes") to throw an exception', () => {
         expect(() => new Phantom('--ignore-ssl-errors=yes')).toThrow();
     });
 
     it('#create(true) to throw an exception', () => {
         expect(() => new Phantom(true)).toThrow();
+    });
+
+    it('#create([], "/path/to/phantomjs") to throw an exception', () => {
+        expect(() => new Phantom([], "/path/to/phantomjs")).toThrow();
     });
 
     it('catches errors when stdin closes unexpectedly', (done) => {


### PR DESCRIPTION
### Proposed changes in this pull request

Added possibility of using custom PhantomJS path by adding 'config' object to Phantom c-tor (with 'phantomPath' property inside).
Added docs and tests.
Tested in production, works well even with older PhantomJS binaries (namely 1.9.8 from npm package phantomjs@1.9.20)

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review
