### PR TITLE
Added a reliable way of loading page contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ phantom - Fast NodeJS API for PhantomJS
 [![Linux Build][travis-image]][travis-url]
 [![Dependencies][david-image]][david-url]
 
-
 ## Super easy to use
 ```js
 var phantom = require('phantom');
@@ -48,15 +47,15 @@ $ npm install phantom --save
 
 ## How does it work?
 
-  [v1.0.x](//github.com/amir20/phantomjs-node/tree/v1) used to use `dnode` to communicate between nodejs and phantomjs. This approach raised a lot of security restrictions and did not work well when using `cluster` or `pm2`.
+[v1.0.x](//github.com/amir20/phantomjs-node/tree/v1) used to use `dnode` to communicate between nodejs and phantomjs. This approach raised a lot of security restrictions and did not work well when using `cluster` or `pm2`.
 
-  v2.0.x has been completely rewritten to use `sysin` and `sysout` pipes to communicate with the phantomjs process. It works out of the box with `cluster` and `pm2`. If you want to see the messages that are sent try adding `DEBUG=true` to your execution, ie. `DEBUG=true node path/to/test.js`. The new code is much cleaner and simpler. PhantomJS is started with `shim.js` which proxies all messages to the `page` or `phantom` object.
+v2.0.x has been completely rewritten to use `sysin` and `sysout` pipes to communicate with the phantomjs process. It works out of the box with `cluster` and `pm2`. If you want to see the messages that are sent try adding `DEBUG=true` to your execution, ie. `DEBUG=true node path/to/test.js`. The new code is much cleaner and simpler. PhantomJS is started with `shim.js` which proxies all messages to the `page` or `phantom` object.
 
 ## Migrating from 1.0.x
 
-  Version 2.0.x is not backward compatible with previous versions. Most notability, method calls do not take a callback function anymore. Since `node` supports `Promise`, each of the methods return a promise. Instead of writing `page.open(url, function(){})` you would have to write `page.open(url).then(function(){})`.
+Version 2.0.x is not backward compatible with previous versions. Most notability, method calls do not take a callback function anymore. Since `node` supports `Promise`, each of the methods return a promise. Instead of writing `page.open(url, function(){})` you would have to write `page.open(url).then(function(){})`.
 
-  The API is much more consistent now. All properties can be read with `page.property(key)` and settings can be read with `page.setting(key)`. See below for more example.
+The API is much more consistent now. All properties can be read with `page.property(key)` and settings can be read with `page.setting(key)`. See below for more example.
 
 ## `phantom` object API
 
@@ -105,11 +104,15 @@ However, be aware that phantomjs process will get detached (and thus won't exit)
 
 ## `page` object API
 
-  The `page` object that is returned with `#createPage` is a proxy that sends all methods to `phantom`. Most method calls should be identical to PhantomJS API. You must remember that each method returns a `Promise`.
+The `page` object that is returned with `#createPage` is a proxy that sends all methods to `phantom`. Most method calls should be identical to PhantomJS API. You must remember that each method returns a `Promise`.
 
-### `page#setContent`
+For list of available methods, properties and events see [PhantomJS documentation of WebPage module](http://phantomjs.org/api/webpage/).
 
-`page.setContent` is used to set content and/or URL address of the page.
+### `page#loadContent`
+
+`page.loadContent` is used to set content and/or URL address of the page.
+
+It differs from `page.invokeMethod('setContent')` by waiting for contents to fully load.
 
 It returns `Promise` resolving after `onLoadFinished` (handled internally), thus providing workaround for [PhantomJS issue #12750](https://github.com/ariya/phantomjs/issues/12750).
 
@@ -139,21 +142,20 @@ page.setting('javascriptEnabled').then(function(value){
 
 ### `page#property`
 
+Page properties can be read using the `#property(key)` method.
 
-  Page properties can be read using the `#property(key)` method.
-
-  ```js
+```js
 page.property('plainText').then(function(content) {
   console.log(content);
 });
-  ```
+```
 
-  Page properties can be set using the `#property(key, value)` method.
+Page properties can be set using the `#property(key, value)` method.
 
-  ```js
+```js
 page.property('viewportSize', {width: 800, height: 600}).then(function() {
 });
-  ```
+```
 When setting values, using `then()` is optional. But beware that the next method to phantom will block until it is ready to accept a new message.
 
 You can set events using `#property()` because they are property members of `page`.
@@ -188,7 +190,6 @@ page.property('onResourceRequested', function(requestData, networkRequest, out) 
 outObj.property('urls').then(function(urls){
    console.log(urls);
 });
-
 ```
 
 ### `page#on`
@@ -309,10 +310,19 @@ page.invokeMethod('evaluate', function(selector) {
 });
 ```
 
+#### `page#invokeMethod('setContent', expectedContent, expectedLocation)`
+
+Set content and/or URL address of the page, without waiting for additional elements to load.
+
+If `page#invokeMethod('render', ...)` is called right after, it might not execute properly (see `page#loadContent` notes).
+
+#### `page#invokeMethod('render', filename, [{format, quality}])`
+
+Renders the page and saves rendered file as `filename`.
 
 ## Tests
 
-  To run the test suite, first install the dependencies, then run `npm test`:
+To run the test suite, first install the dependencies, then run `npm test`:
 
 ```bash
 $ npm install
@@ -321,17 +331,17 @@ $ npm test
 
 ## Contributing
 
-  This package is under development. Pull requests are welcomed. Please make sure tests are added for new functionalities and that your build does pass in TravisCI.
+This package is under development. Pull requests are welcomed. Please make sure tests are added for new functionalities and that your build does pass in TravisCI.
 
 ## People
 
-  The current lead maintainer is [Amir Raminfar](https://github.com/amir20)
+The current lead maintainer is [Amir Raminfar](https://github.com/amir20)
 
-  [List of all contributors](https://github.com/amir20/phantomjs-node/graphs/contributors)
+[List of all contributors](https://github.com/amir20/phantomjs-node/graphs/contributors)
 
 ## License
 
-  [ISC](LICENSE.md)
+[ISC](LICENSE.md)
 
 [npm-image]: https://img.shields.io/npm/v/phantom.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/phantom

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ However, be aware that phantomjs process will get detached (and thus won't exit)
 
   The `page` object that is returned with `#createPage` is a proxy that sends all methods to `phantom`. Most method calls should be identical to PhantomJS API. You must remember that each method returns a `Promise`.
 
+### `page#setContent`
+
+`page.setContent` is used to set content and/or URL address of the page.
+
+It returns `Promise` resolving after `onLoadFinished` (handled internally), thus providing workaround for [PhantomJS issue #12750](https://github.com/ariya/phantomjs/issues/12750).
+
+The returned `Promise` can yield `'success'` or `'fail'`, as per [PhantomJS WebPage documentation](http://phantomjs.org/api/webpage/handler/on-load-finished.html), or `false` in case of IPC error.
+
+```js
+let htmlContent = '<html><head><title>setContent Title</title></head><body></body></html>';
+let pageLocation = 'http://localhost:8888/';
+page.setContent(htmlContent, pageLocation).then(function (result) {
+	if(result === 'success') {
+		console.log('Page contents set!');
+		// Other operations...
+		return page.invokeMethod('render', '/path/to/output/file', { format: 'pdf' });
+	}
+});
+```
+
 ### `page#setting`
 
 `page.settings` can be accessed via `page.setting(key)` or set via `page.setting(key, value)`. Here is an example to read `javascriptEnabled` property.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "phantom",
   "description": "PhantomJS integration module for NodeJS",
   "homepage": "https://github.com/amir20/phantomjs-node",
-  "version": "2.1.12",
+  "version": "2.1.13-rc1",
   "repository": {
     "type": "git",
     "url": "git://github.com/amir20/phantomjs-node.git"

--- a/src/page.js
+++ b/src/page.js
@@ -80,11 +80,11 @@ export default class Page {
     }
 
     /**
-     * Set contents of the page
+     * Set contents of the page and wait for them to load
      * @param {string} html Page content
      * @param {string} url Page URL
      */
-    setContent() {
+    loadContent() {
         return this.phantom.execute(this.target, 'loadPageContent', [].slice.call(arguments));
     }
 }
@@ -107,6 +107,7 @@ const methods = [
     'render',
     'renderBase64',
     'sendEvent',
+    'setContent',
     'setProxy',
     'stop',
     'switchToFrame',

--- a/src/page.js
+++ b/src/page.js
@@ -43,40 +43,49 @@ export default class Page {
     off(event) {
         return this.phantom.off(event, this.target);
     }
-    
+
     /**
      * Invokes an asynchronous method
      */
     invokeAsyncMethod() {
         return this.phantom.execute(this.target, 'invokeAsyncMethod', [].slice.call(arguments));
     }
-    
+
     /**
      * Invokes a method
      */
     invokeMethod() {
         return this.phantom.execute(this.target, 'invokeMethod', [].slice.call(arguments));
     }
-    
+
     /**
      * Defines a method
      */
     defineMethod(name, definition) {
         return this.phantom.execute(this.target, 'defineMethod', [name, definition]);
     }
-    
+
     /**
      * Gets or sets a property
      */
     property() {
         return this.phantom.execute(this.target, 'property', [].slice.call(arguments));
     }
-    
+
     /**
      * Gets or sets a setting
      */
     setting() {
         return this.phantom.execute(this.target, 'setting', [].slice.call(arguments));
+    }
+
+    /**
+     * Set contents of the page
+     * @param {string} html Page content
+     * @param {string} url Page URL
+     */
+    setContent() {
+        return this.phantom.execute(this.target, 'loadPageContent', [].slice.call(arguments));
     }
 }
 
@@ -92,13 +101,12 @@ const methods = [
     'deleteCookie',
     'evaluate',
     'evaluateJavaScript',
-    'injectJs', 
+    'injectJs',
     'openUrl',
     'reload',
     'render',
     'renderBase64',
     'sendEvent',
-    'setContent',
     'setProxy',
     'stop',
     'switchToFrame',
@@ -108,11 +116,11 @@ const methods = [
 asyncMethods.forEach(method => {
     Page.prototype[method] = function () {
         return this.invokeAsyncMethod.apply(this, [method].concat([].slice.call(arguments)));
-    }; 
+    };
 });
 
 methods.forEach(method => {
     Page.prototype[method] = function () {
         return this.invokeMethod.apply(this, [method].concat([].slice.call(arguments)));
-    }
+    };
 });

--- a/src/shim.js
+++ b/src/shim.js
@@ -91,8 +91,24 @@ const commands = {
         completeCommand(command);
     },
 
+    loadPageContent: function (command) {
+        let page = objectSpace[command.target];
+        if(!page) {
+            command.response = false;
+            return completeCommand(command);
+        }
+
+        page.onLoadFinished = result => {
+            page.onLoadFinished = null;
+            command.response = result;
+            completeCommand(command);
+        }
+
+        page.setContent(command.params[0], command.params[1]);
+    },
+
     noop: command => completeCommand(command),
-    
+
     invokeAsyncMethod: function (command) {
         let target = objectSpace[command.target];
         target[command.params[0]].apply(target, command.params.slice(1).concat(result => {
@@ -100,14 +116,14 @@ const commands = {
             completeCommand(command);
         }));
     },
-    
+
     invokeMethod: function (command) {
         let target = objectSpace[command.target];
         let method = target[command.params[0]];
         command.response = method.apply(target, command.params.slice(1));
         completeCommand(command);
     },
-    
+
     defineMethod: function (command) {
         let target = objectSpace[command.target];
         target[command.params[0]] = command.params[1];

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -290,6 +290,18 @@ describe('Page', () => {
         expect(response).toEqual(['setContent Title', 'http://localhost:8888/']);
     });
 
+    it('#loadContent() works like setContent but waits for page load', function*() {
+        let page = yield phantom.createPage();
+        let html = '<html><head><script>for(var i=0;i<1000000;i++){document.title="loadContent test "+i;}; document.title="loadContent Title"</script></head><body></body></html>';
+
+        yield page.setContent(html, 'http://localhost:8888/');
+
+        let response = yield page.evaluate(function () {
+            return [document.title, location.href];
+        });
+
+        expect(response).toEqual(['loadContent Title', 'http://localhost:8888/']);
+    });
 
     it('#sendEvent() sends an event', function*() {
         let page = yield phantom.createPage();
@@ -493,11 +505,11 @@ describe('Page', () => {
         // confirm we are in the main frame
         expect(inMainFrame).toBe(true);
     });
-    
+
     it('#reload() will reload the current page', function*() {
         let page = yield phantom.createPage();
         let reloaded = false;
-        
+
         yield page.open('http://localhost:8888/test');
         yield page.on('onNavigationRequested', function(url, type) {
             if (type === 'Reload') {
@@ -505,10 +517,10 @@ describe('Page', () => {
             }
         });
         yield page.reload();
-        
+
         expect(reloaded).toBe(true);
     });
-    
+
     it('#invokeAsyncMethod(\'includeJs\', \'http://localhost:8888/script.js\') executes correctly', function*() {
         let page = yield phantom.createPage();
         yield page.open('http://localhost:8888/test');
@@ -518,27 +530,27 @@ describe('Page', () => {
         });
         expect(response).toEqual(2);
     });
-    
+
     it('#invokeAsyncMethod(\'open\', \'http://localhost:8888/test\') executes correctly', function*() {
         let page = yield phantom.createPage();
         let status = yield page.invokeAsyncMethod('open', 'http://localhost:8888/test');
         expect(status).toEqual('success');
     });
-    
+
     it('#invokeMethod(\'evaluate\', \'function () { return document.title }\') executes correctly', function*() {
         let page = yield phantom.createPage();
         yield page.open('http://localhost:8888/test.html');
         let response = yield page.invokeMethod('evaluate', 'function () { return document.title }');
-        expect(response).toEqual('Page Title'); 
+        expect(response).toEqual('Page Title');
     });
-    
+
     it('#invokeMethod(\'renderBase64\') executes correctly', function*() {
         let page = yield phantom.createPage();
         yield page.open('http://localhost:8888/test');
         let content = yield page.invokeMethod('renderBase64', 'PNG');
         expect(content).not.toBeNull();
     });
-    
+
     it('#defineMethod(name, definition) defines a method', function*() {
         let page = yield phantom.createPage();
         yield page.defineMethod('getZoomFactor', function() {
@@ -547,7 +559,7 @@ describe('Page', () => {
         let zoomFactor = yield page.invokeMethod('getZoomFactor');
         expect(zoomFactor).toEqual(1);
     });
-    
+
     it('#openUrl() opens a URL', function(done) {
         phantom.createPage().then(function(page) {
             page.on('onLoadFinished', false, function(status) {
@@ -557,7 +569,7 @@ describe('Page', () => {
             return page.openUrl('http://localhost:8888/test', 'GET', {});
         });
     });
-    
+
     it('#setProxy() sets the proxy', function*() {
         let page = yield phantom.createPage();
         yield page.setProxy('http://localhost:8888');
@@ -565,6 +577,6 @@ describe('Page', () => {
         let text = yield page.property('plainText');
         expect(text).toEqual('hi, http://phantomjs.org/');
     });
-    
+
 });
 

--- a/src/spec/phantom_spec.js
+++ b/src/spec/phantom_spec.js
@@ -40,7 +40,7 @@ describe('Phantom', () => {
                 path: null
             }
         }).default;
-        
+
         expect(() => new ProxyPhantom()).toThrow();
     });
 
@@ -55,15 +55,16 @@ describe('Phantom', () => {
         pp.exit();
     });
 
-    it('#create([], {phantomPath: \'phantomjs\'}) execute phantomjs from custom path with no parameters', () => {
+    it('#create([], {phantomPath: \'custom/phantom/path\'}) executes phantomjs from custom path with no parameters', () => {
         spyOn(child_process, 'spawn').and.callThrough();
         let ProxyPhantom = proxyquire('../phantom', {
             child_process: child_process
         }).default;
 
-        let pp = new ProxyPhantom([], {phantomPath: 'phantomjs'});
+        let pathToPhantom = path.normalize(__dirname + '/../../node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs');
+        let pp = new ProxyPhantom([], {phantomPath: pathToPhantom});
         let pathToShim = path.normalize(__dirname + '/../shim.js');
-        expect(child_process.spawn).toHaveBeenCalledWith('phantomjs', [pathToShim]);
+        expect(child_process.spawn).toHaveBeenCalledWith(pathToPhantom, [pathToShim]);
         pp.exit();
     });
 


### PR DESCRIPTION
### Proposed changes in this pull request

Created page#loadContent(), which works more or less like setContent() in pre-2.x releases.
Essentially it calls setContent() but resolves on onPageLoaded instead of immediately, thus providing kind of workaround for [PhantomJS issue with crashing on rendering not-fully-loaded pages](https://github.com/ariya/phantomjs/issues/12750).

Added docs with additional notes on difference between loadContent and setContent.
Added test unit, which while not being the cleanest one still tests the expected functionality.

Test build is available [here](https://github.com/greatcare/phantomjs-node/releases/tag/v2.1.13-rc2).
As in our previous pull request, the build has been tested and proven to work in a real environment (in which we had problems with setContent()).

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated

@amir20 to review
