### PR TITLE
Fix hanging crash when passing null to page#evaluate

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -153,7 +153,9 @@ function transform(object) {
     for (let key in object) {
         if (object.hasOwnProperty(key)) {
             let child = object[key];
-            if (child.transform === true) {
+            if (child === null || child === undefined) {
+                return;
+            } else if (child.transform === true) {
                 object[key] = objectSpace[child.parent][child.method](child.target);
             } else if (typeof child === 'object') {
                 transform(child);

--- a/src/spec/page_spec.js
+++ b/src/spec/page_spec.js
@@ -124,6 +124,22 @@ describe('Page', () => {
         expect(response).toEqual('test');
     });
 
+    it('#evaluate(function(arg){...}, argument) executes correctly with a non-null argument', function*() {
+        let page = yield phantom.createPage();
+        let response = yield page.evaluate(function (arg) {
+            return 'Value: ' + arg;
+        }, 'test');
+        expect(response).toEqual('Value: test');
+    });
+
+    it('#evaluate(function(arg){...}, argument) executes correctly with a null argument', function*() {
+        let page = yield phantom.createPage();
+        let response = yield page.evaluate(function (arg) {
+            return 'Value is null: ' + (arg === null);
+        }, null);
+        expect(response).toEqual('Value is null: true');
+    });
+
     it('#evaluateJavaScript(\'function(){return document.title}\') executes correctly', function*() {
         let page = yield phantom.createPage();
         yield page.open('http://localhost:8888/test.html');


### PR DESCRIPTION
### Proposed changes in this pull request

phantom-node currently hangs indefinitely if you try to pass an argument of `null` or `undefined` to the `page#evaluate` method. For example:

```
var Phantom = require('phantom');

var sitepage = null;
var phInstance = null;
Phantom.create()
  .then(instance => {
    phInstance = instance;
    return instance.createPage();
  }).then(page => {
    sitepage = page;
    return page.open('http://httpbin.org/get');
  }).then(status => {
    sitepage.evaluate(function(val) {
      return "Hello world! Parameter value = "+val;
    }, null).then(function(result){
      console.log(result);
    });
  })
  .then(() => {
    sitepage.close();
    phInstance.exit();
  })
  .catch(error => {
    console.log(error);
    phInstance.exit();
  });;
```

This PR updates the `transform` method to properly handle both `null` and `undefined`.

#### Checklist
* [x] New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated (I figured no documentation updates were necessary, but I'm happy to add documentation for passing parameters into `page#evaluate` if desired)

@amir20 to review
