### PR TITLE
shim.js: add Function.prototype.bind fallback

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -2,6 +2,36 @@ import webpage from "webpage";
 import system from "system";
 
 /**
+ * Ensure that Function has bind() method (PhantomJS version <= 1.9 support)
+ * This is a Polyfill replacement from MDN.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill}
+ */
+/* eslint-disable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
+if (!Function.prototype.bind) {
+    Function.prototype.bind = function (oThis) {
+        if (typeof this !== 'function') {
+            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+        }
+
+        let self = this;
+        let aArgs = Array.prototype.slice.call(arguments, 1);
+        function NoopFunction() {}
+        function boundFunction() {
+            return self.apply((this instanceof NoopFunction ? this : oThis), aArgs.concat(Array.prototype.slice.call(arguments)));
+        }
+
+        if (this.prototype) {
+            NoopFunction.prototype = this.prototype;
+        }
+        boundFunction.prototype = new NoopFunction();
+
+        return boundFunction;
+    };
+}
+
+/* eslint-enable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
+
+/**
  * Stores all all pages and single instance of phantom
  */
 const objectSpace = {

--- a/src/shim.js
+++ b/src/shim.js
@@ -1,35 +1,6 @@
 import webpage from "webpage";
 import system from "system";
-
-/**
- * Ensure that Function has bind() method (PhantomJS version <= 1.9 support)
- * This is a Polyfill replacement from MDN.
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill}
- */
-/* eslint-disable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
-if (!Function.prototype.bind) {
-    Function.prototype.bind = function (oThis) {
-        if (typeof this !== 'function') {
-            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-        }
-
-        let self = this;
-        let aArgs = Array.prototype.slice.call(arguments, 1);
-        function NoopFunction() {}
-        function boundFunction() {
-            return self.apply((this instanceof NoopFunction ? this : oThis), aArgs.concat(Array.prototype.slice.call(arguments)));
-        }
-
-        if (this.prototype) {
-            NoopFunction.prototype = this.prototype;
-        }
-        boundFunction.prototype = new NoopFunction();
-
-        return boundFunction;
-    };
-}
-
-/* eslint-enable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
+import {ensureFunctionBind} from "./shim_support";
 
 /**
  * Stores all all pages and single instance of phantom
@@ -301,4 +272,5 @@ function completeCommand(command) {
     setTimeout(read, 0);
 }
 
+ensureFunctionBind();
 read();

--- a/src/shim_support.js
+++ b/src/shim_support.js
@@ -1,0 +1,35 @@
+
+/* eslint-disable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
+
+/**
+ * Ensure that Function has bind() method (PhantomJS version <= 1.9 support)
+ * This is a Polyfill replacement from MDN.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill}
+ */
+function ensureFunctionBind() {
+    if (!Function.prototype.bind) {
+        Function.prototype.bind = function (oThis) {
+            if (typeof this !== 'function') {
+                throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+            }
+
+            let self = this;
+            let aArgs = Array.prototype.slice.call(arguments, 1);
+            function NoopFunction() {}
+            function boundFunction() {
+                return self.apply((this instanceof NoopFunction ? this : oThis), aArgs.concat(Array.prototype.slice.call(arguments)));
+            }
+
+            if (this.prototype) {
+                NoopFunction.prototype = this.prototype;
+            }
+            boundFunction.prototype = new NoopFunction();
+
+            return boundFunction;
+        };
+    }
+}
+
+/* eslint-enable no-extend-native, consistent-this, require-jsdoc, no-empty-function, no-invalid-this */
+
+export {ensureFunctionBind}


### PR DESCRIPTION
### Proposed changes in this pull request

Added Function.prototype.bind fallback (based on [Polyfill implementation on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill)) for compatibility with PhantomJS 1.9.x and earlier.

This is a much cleaner solution to issue raised in #508.

Test wasn't added as it would require adding yet another PhantomJS binary to devDependencies (and pulling additional ~60MBs).

#### Checklist
* ~~[ ] New tests have been added~~ See note above
* [x] `npm test` passes successfully
* ~~[ ] Documentation has been updated~~ N/A


@amir20 to review