### PR TITLE
Fix detection of arrow functions

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -152,6 +152,23 @@ export default class Phantom {
      * @returns {Promise}
      */
     executeCommand(command) {
+        this.commands.set(command.id, command);
+
+        let json = JSON.stringify(command, (key, val) => {
+            let r;
+            if (key[0] === '_') {
+                r = undefined;
+            } else {
+                let isFunction = typeof val === 'function';
+                if (isFunction && !val.hasOwnProperty('prototype')) {
+                    logger.warn('Arrow functions such as () => {} are not supported in PhantomJS. Please use function(){} or compile to ES5.');
+                    throw new Error('Arrow functions such as () => {} are not supported in PhantomJS.');
+                }
+                r = isFunction ? val.toString() : val;
+            }
+            return r;
+        });
+
         command.deferred = {};
 
         let promise = new Promise((res, rej) => {
@@ -159,25 +176,10 @@ export default class Phantom {
             command.deferred.reject = rej;
         });
 
-        this.commands.set(command.id, command);
-
-        let json = JSON.stringify(command, (key, val) => {
-            let r;
-            if (key[0] === '_') {
-                r = undefined
-            } else {
-                r = typeof val === 'function' ? val.toString() : val;
-
-                if(typeof val === 'function' && r.indexOf('(') === 0) {
-                    logger.warn('Arrow functions such as () => {} are not supported in PhantomJS. Please use function(){} or compile to ES5.');
-                    throw new Error('Arrow functions such as () => {} are not supported in PhantomJS.');
-                }
-            }
-            return r;
-        });
         logger.debug('Sending: %s', json);
 
         this.process.stdin.write(json + os.EOL, 'utf8');
+
         return promise;
     }
 

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -168,7 +168,7 @@ export default class Phantom {
             } else {
                 r = typeof val === 'function' ? val.toString() : val;
 
-                if(typeof val === 'function' && r.includes('=>')) {
+                if(typeof val === 'function' && r.indexOf('(') === 0) {
                     logger.warn('Arrow functions such as () => {} are not supported in PhantomJS. Please use function(){} or compile to ES5.');
                     throw new Error('Arrow functions such as () => {} are not supported in PhantomJS.');
                 }


### PR DESCRIPTION
It no longer confuses 'normal' functions that contain the character sequence '=>' for arrow functions.

#### Checklist
* [ ] New tests have been added
* [x] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

