### PR TITLE
Replace crypto.randomBytes() with Math.random() to address #563

### DIFF
--- a/src/__test__/command.spec.js
+++ b/src/__test__/command.spec.js
@@ -2,7 +2,7 @@ import Command from '../command';
 
 describe('Command', () => {
     it('id to be randomly generated', () => {
-        expect(new Command().id).toMatch(/[\da-f]{16}/);
+        expect(new Command().id).toMatch(/[\da-z]{16}/);
     });
 
     it('id to be set correctly', () => {

--- a/src/command.js
+++ b/src/command.js
@@ -1,4 +1,5 @@
 // @flow
+import randId from './util/random_id';
 
 /**
  * A simple command class that gets deserialized when it is sent to phantom
@@ -17,19 +18,4 @@ export default class Command {
         this.params = params;
         this.deferred = null;
     }
-}
-
-/**
- * Generate an ascii random ID
- * 
- * @param  {Number} bytes number of bytes the ID should contain
- * @return {String} a textual ID of `bytes` entropy
- */
-function randId(bytes) {
-    var ret = [];
-    for( ; bytes > 0 ; bytes -= 4 ) {
-        // Make a unique string of pow(2, 32) entropy.
-        ret.push(((Math.random()*(-1>>>0))>>>0).toString(36)); // number in base 36 (to save space)
-    }
-    return ret.join('');
 }

--- a/src/command.js
+++ b/src/command.js
@@ -1,7 +1,5 @@
 // @flow
 
-import crypto from 'crypto';
-
 /**
  * A simple command class that gets deserialized when it is sent to phantom
  */
@@ -13,10 +11,25 @@ export default class Command {
     deferred: ?{resolve: Function, reject: Function};
 
     constructor(id: ?string, target: string, name: string, params:mixed[] = []) {
-        this.id = id || crypto.randomBytes(16).toString('hex');
+        this.id = id || randId(16);
         this.target = target;
         this.name = name;
         this.params = params;
         this.deferred = null;
     }
+}
+
+/**
+ * Generate an ascii random ID
+ * 
+ * @param  {Number} bytes number of bytes the ID should contain
+ * @return {String} a textual ID of `bytes` entropy
+ */
+function randId(bytes) {
+    var ret = [];
+    for( ; bytes > 0 ; bytes -= 4 ) {
+        // Make a unique string of pow(2, 32) entropy.
+        ret.push(((Math.random()*(-1>>>0))>>>0).toString(36)); // number in base 36 (to save space)
+    }
+    return ret.join('');
 }

--- a/src/out_object.js
+++ b/src/out_object.js
@@ -1,6 +1,5 @@
 // @flow
 import Phantom from './phantom';
-import crypto from 'crypto';
 
 export default class OutObject {
     _phantom: Phantom;
@@ -8,10 +7,25 @@ export default class OutObject {
 
     constructor(phantom:Phantom) {
         this._phantom = phantom;
-        this.target = 'OutObject$' + crypto.randomBytes(16).toString('hex');
+        this.target = 'OutObject$' + randId(16);
     }
 
     property(name: string) {
         return this._phantom.execute(this.target, 'property', [name]);
     }
+}
+
+/**
+ * Generate an ascii random ID
+ * 
+ * @param  {Number} bytes number of bytes the ID should contain
+ * @return {String} a textual ID of `bytes` entropy
+ */
+function randId(bytes) {
+    var ret = [];
+    for( ; bytes > 0 ; bytes -= 4 ) {
+        // Make a unique string of pow(2, 32) entropy.
+        ret.push(((Math.random()*(-1>>>0))>>>0).toString(36)); // number in base 36 (to save space)
+    }
+    return ret.join('');
 }

--- a/src/out_object.js
+++ b/src/out_object.js
@@ -1,5 +1,6 @@
 // @flow
 import Phantom from './phantom';
+import randId from './util/random_id';
 
 export default class OutObject {
     _phantom: Phantom;
@@ -13,19 +14,4 @@ export default class OutObject {
     property(name: string) {
         return this._phantom.execute(this.target, 'property', [name]);
     }
-}
-
-/**
- * Generate an ascii random ID
- * 
- * @param  {Number} bytes number of bytes the ID should contain
- * @return {String} a textual ID of `bytes` entropy
- */
-function randId(bytes) {
-    var ret = [];
-    for( ; bytes > 0 ; bytes -= 4 ) {
-        // Make a unique string of pow(2, 32) entropy.
-        ret.push(((Math.random()*(-1>>>0))>>>0).toString(36)); // number in base 36 (to save space)
-    }
-    return ret.join('');
 }

--- a/src/util/random_id.js
+++ b/src/util/random_id.js
@@ -1,0 +1,15 @@
+
+/**
+ * Generate an ascii random ID
+ * 
+ * @param  {Number} minBytes number of bytes the ID should contain
+ * @return {String} a textual ID of `bytes` entropy
+ */
+export default function randId(minBytes: number) {
+    const ret = [];
+    for( ; minBytes > 0 ; minBytes -= 4 ) {
+        // Make a unique string of pow(2, 32) entropy.
+        ret.push( (Math.random()*(-1>>>0)>>>0).toString(36) ); // number in base 36 (to save space)
+    }
+    return ret.join('');
+}


### PR DESCRIPTION
`Math.random()` is of lower quality then `crypto.randomBytes()`, but is much faster and doesn't consume system's entropy.