### PR TITLE
exit() now returns promise

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -308,9 +308,9 @@ export default class Phantom {
     /**
      * Cleans up and end the phantom process
      */
-    exit(): void {
+    exit(): Promise {
         clearInterval(this.heartBeatId);
-        this.execute('phantom', 'invokeMethod', ['exit']);
+        return this.execute('phantom', 'invokeMethod', ['exit']);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

Exitting now returns Promise in order to be able to wait properly.

@amir20 to review

