### PR TITLE
Fix babel warnings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 6.9
+        "node": "6.9"
       }
     }]
   ],


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes babel warnings, that flood the logs during tests: 
```
We recommend using a string for minor/patch versions to avoid numbers like 6.10
getting parsed as 6.1, which can lead to unexpected behavior.

Warning, the following targets are using a decimal version:

    node: 6.9
```
Example: https://travis-ci.org/amir20/phantomjs-node/jobs/237976527

#### Checklist
* [ ] New tests have been added - not required
* [x] `npm test` passes successfully
* [ ] Documentation has been updated - not required


@amir20 to review
