### PR TITLE
fix: logger

### DIFF
--- a/decls/logger.js
+++ b/decls/logger.js
@@ -1,4 +1,4 @@
-declare class Logger {
+declare type Logger = {
     info(s: string, ...params: any[]): void;
     debug(s: string, ...params: any[]): void;
     error(s: string, ...params: any[]): void;

--- a/src/__test__/index.spec.js
+++ b/src/__test__/index.spec.js
@@ -23,7 +23,7 @@ describe('index.js', () => {
 
     it('#create([], {}) errors with string for logger', async () => {
         await expect(phantom.create([], {logger: 'log'})).rejects
-            .toEqual(new Error('logger must be ba valid object.'));
+            .toEqual(new Error('logger must be a valid object.'));
     });
 
     it('#create([], {}) errors with string for logger', async () => {

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -68,16 +68,16 @@ export default class Phantom {
                 'This generally means something went wrong when installing phantomjs-prebuilt. Exiting.');
         }
 
-        if (typeof logger !== 'object') {
-            throw new Error('logger must be ba valid object.');
+        if (!logger.info && !logger.debug && !logger.error && !logger.warn ) {
+            throw new Error('logger must be a valid object.');
         }
 
-        logger.debug = logger.debug || (() => undefined);
-        logger.info = logger.info || (() => undefined);
-        logger.warn = logger.warn || (() => undefined);
-        logger.error = logger.error || (() => undefined);
-
-        this.logger = logger;
+        this.logger = {
+            info: logger.info && ((...args) => logger.info(...args)) || (() => undefined),
+            debug: logger.debug && ((...args) => logger.debug(...args)) || (() => undefined),
+            error: logger.error && ((...args) => logger.error(...args)) || (() => undefined),
+            warn: logger.warn && ((...args) => logger.warn(...args)) || (() => undefined),
+        };
 
         if (logLevel !== defaultLogLevel) {
             this.logger = createLogger();


### PR DESCRIPTION
I was going to open an issue that I had a custom logger object whose `typeof` was a function and so it gave the error "logger must be a valid object". I dug in the code and it seems this could be an easy fix but I'm not sure, have a look at this PR anyway and let me know if you're ok with this approach. This probably messes with the winston logging you've got going, so I haven't bothered with failing tests yet. 

### Proposed changes in this pull request

* Allows logger to be anything other than object

* Doesn't change the original logger object when polyfilling debug/info methods

* Preserves `this` when calling methods on original logger object

#### Checklist
* [ ] New tests have been added
* [ ] `npm test` passes successfully
* [ ] Documentation has been updated


@amir20 to review

PS: awesome library!
