### PR TITLE
Allowing custom shim path to be used during Phantom creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ phantom.create(['--ignore-ssl-errors=yes', '--load-images=no']).then(...)
 You can also explicitly set :
 
 - The phantomjs path to use
+- The path to the shim/index.js to use
 - A logger object
 - A log level if no logger was specified
 
@@ -93,6 +94,7 @@ by passing them in config object:
 var phantom = require('phantom');
 phantom.create([], {
     phantomPath: '/path/to/phantomjs',
+    shimPath: '/path/to/shim/index.js',
     logger: yourCustomLogger,
     logLevel: 'debug',
 }).then(...)

--- a/decls/config.js
+++ b/decls/config.js
@@ -1,5 +1,6 @@
 declare class Config {
     logger: Logger;
     phantomPath: string;
+    shimPath: string;
     logLevel: string;
 }

--- a/src/__test__/index.spec.js
+++ b/src/__test__/index.spec.js
@@ -13,10 +13,21 @@ describe('index.js', () => {
     return promise.then(ph => ph.exit());
   });
 
+  it('phantom#create([], {}).then() with a custom shim path returns a new Phantom instance', () => phantom.create([], { shimPath: `${__dirname}/shim/index.js` }).then((ph) => {
+    expect(ph).toBeInstanceOf(Phantom);
+    ph.exit();
+  }));
+
   it('#create([], {}) errors with undefined phantomjs-prebuilt to throw exception', async () => {
     await expect(phantom.create([], { phantomPath: null })).rejects
       .toEqual(new Error('PhantomJS binary was not found. ' +
                 'This generally means something went wrong when installing phantomjs-prebuilt. Exiting.'));
+  });
+
+  it('#create([], {}) errors with non-string passed in as shimPath', async () => {
+    await expect(phantom.create([], { shimPath: 12 })).rejects
+      .toEqual(new Error('Path to shim file was not found. ' +
+                'Are you sure you entered the path correctly? Exiting.'));
   });
 
   it('#create([], {}) errors with string for logger', async () => {


### PR DESCRIPTION
### Proposed changes in this pull request

### NOTE: 
For some reason, I get the error:
```
Error: src/phantom.js:80
 80:     this.logger.debug(`Starting ${phantomPath} ${args.join(' ')}`);
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused function argument
   75:       debug: logger.debug ? (...msg) => logger.debug(...msg) : () => undefined,
                                                                      ^^^^^^^^^^^^^^^ function expects no arguments
```

When I try to remove line 81, or:
```
 const pathToShim = path.normalize(`${__dirname}/shim/index.js`);  // eslint-disable-line 
```
from the file `src/phantom.js`. Do you have any idea why this would be?


This PR allows users to pass in where their shim/index.js file is located. This is useful when this library is being used in contexts such as AWS lambda, where the location `__dirname` will lead the program to is not correct.

#### Checklist
* [x]  New tests have been added
* [x] `npm test` passes successfully
* [x] Documentation has been updated


@amir20 to review
